### PR TITLE
Add GitHub workflow to push Docker image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,30 @@
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+
+  build:
+    name: Build, push, and deploy
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout master
+      uses: actions/checkout@v2
+
+    - name: Build PostgresQL container image
+      run: docker build --build-arg DATABASE_TYPE=postgresql --tag docker.pkg.github.com/mikecao/umami/umami:postgresql-$(echo $GITHUB_SHA | head -c7) .
+
+    - name: Build MySQL container image
+      run: docker build --build-arg DATABASE_TYPE=mysql --tag docker.pkg.github.com/mikecao/umami/umami:mysql-$(echo $GITHUB_SHA | head -c7) .
+
+    - name: Docker login
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: docker login -u mikecao -p $GITHUB_TOKEN docker.pkg.github.com
+      
+    - name: Push image to GitHub
+      run: |
+        docker push docker.pkg.github.com/mikecao/umami/umami:postgresql-$(echo $GITHUB_SHA | head -c7)
+        docker push docker.pkg.github.com/mikecao/umami/umami:mysql-$(echo $GITHUB_SHA | head -c7)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,6 @@
 on:
-  push:
-    branches:
-      - master
+  release:
+    types: [published]
 
 jobs:
 


### PR DESCRIPTION
Closes #54.

This adds a GitHub workflow to push an Umami Docker image to GitHub Packages.

At the moment it's building a separate image for MySQL and Postgres — I wonder if it makes more sense to run `copy-db-schema.js` on start up, rather than as part of the build process, then we could just use a single image.

Right now the script runs when there's a new push to the main branch, but it might be worthwhile making it only run for new tags (if you want to do tagged releases). It's easy enough to change regardless 🤷🏻 

It uses the `GITHUB_TOKEN` provided in the CI runner, which is tied to your account, but doesn't need to be set.

Here's an example of the published image: https://github.com/hugomd/umami/packages/369037
Likewise, here's the action running successfully: https://github.com/hugomd/umami/runs/1017818531

A caveat with images hosted on GitHub is that they require user authentication to perform `docker pull`. As far as I know, anyone with a GitHub account can pull them, they just need to authenticate first.