### PR TITLE
Check window.external before checking msTrackingProtectionEnabled

### DIFF
--- a/lib/web.js
+++ b/lib/web.js
@@ -52,7 +52,7 @@ export const doNotTrack = () => {
     window.doNotTrack ||
     navigator.doNotTrack ||
     navigator.msDoNotTrack ||
-    'msTrackingProtectionEnabled' in window.external
+    (window.external && 'msTrackingProtectionEnabled' in window.external)
   ) {
     if (
       window.doNotTrack == '1' ||


### PR DESCRIPTION
I tried updated version of umami after PR #48 is merged, however there was another code that was referencing `window.external`. 

This PR adds another check on doNotTrack() before checking `msTrackingProtectionEnabled`'s existence.