### PR TITLE
Generic AIP collect URL allowing subfolders

### DIFF
--- a/tracker/index.js
+++ b/tracker/index.js
@@ -17,7 +17,7 @@ import { post, hook, doNotTrack } from '../lib/web';
   if (!script || (__DNT__ && doNotTrack())) return;
 
   const website = script.getAttribute('data-website-id');
-  const hostUrl = new URL(script.src).href.replace(/\/umami\.js$/,'');
+  const hostUrl = new URL(script.src).href.split('/').slice(0, -1).join('/');
   const screen = `${width}x${height}`;
   const listeners = [];
 

--- a/tracker/index.js
+++ b/tracker/index.js
@@ -17,7 +17,7 @@ import { post, hook, doNotTrack } from '../lib/web';
   if (!script || (__DNT__ && doNotTrack())) return;
 
   const website = script.getAttribute('data-website-id');
-  const hostUrl = new URL(script.src).origin;
+  const hostUrl = new URL(script.src).href.replace(/\/umami\.js$/,'');
   const screen = `${width}x${height}`;
   const listeners = [];
 


### PR DESCRIPTION
I've changed the fetching of "hostUrl" variable to match not only domain, but the subfolder as well. The thing is I've installed the analytics to subfolder "/myfolder/" but when I used the code, the tracker tries to send the data to "mydomain.com/api/collect" instead of correct "mydomain.com/myfolder/api/collect". This change fixes the issue. It's not pretty to filter out the name of the script from the path by .replace, but I wasn't able to find better solution to get the subfolder. If you do, please change it :)