### PR TITLE
Update getDatabase to lookup DATABASE_TYPE env

### DIFF
--- a/lib/queries.js
+++ b/lib/queries.js
@@ -6,7 +6,7 @@ const POSTGRESQL = 'postgresql';
 const MYSQL = 'mysql';
 
 export function getDatabase() {
-  return process.env.DATABASE_URL.split(':')[0];
+  return process.env.DATABASE_TYPE || process.env.DATABASE_URL.split(':')[0];
 }
 
 export async function getWebsiteById(website_id) {


### PR DESCRIPTION
First, thanks for making this awesome project! :tada: 

While working on deploying this service to my [dokku](http://dokku.viewdocs.io/dokku/) instance, I found that the DATABASE_URL produced by [linking the Postgres service with the umami service](http://dokku.viewdocs.io/dokku/deployment/application-deployment/#create-the-backing-services) used `postgres://` instead of `postgresql://` as expected by umami. I set the DATABASE_TYPE environment variable in the umami container to fix the `copy-db-schema` step but still had issues on the dashboard page after adding a website in the settings. 

I was able to fix this issue by updating the `getDatabase` function in `lib/queries.js` to use the DATABASE_TYPE environment variable before the DATABASE_URL like the `copy-db-schema` script. 