### PR TITLE
Fix active button style in Safari

### DIFF
--- a/components/common/Button.module.css
+++ b/components/common/Button.module.css
@@ -17,6 +17,10 @@
   background: #eaeaea;
 }
 
+.button:active {
+  color: initial;
+}
+
 .large {
   font-size: var(--font-size-large);
 }


### PR DESCRIPTION
WebKit changes the colour of a button in the active state by default to `activebuttontext`. This PR fixes the text becoming illegible when a button is active in the Safari browser.

**Before:**

![umami-buttons-before](https://user-images.githubusercontent.com/7896438/91937125-ee350a80-ed0e-11ea-9a48-c3267b54adee.gif)

**After:**

![umami-buttons-after](https://user-images.githubusercontent.com/7896438/91937138-f4c38200-ed0e-11ea-840d-c4d89f089f02.gif)
