### PR TITLE
Rearrange date range dropdown logically

### DIFF
--- a/components/common/DateFilter.js
+++ b/components/common/DateFilter.js
@@ -3,13 +3,12 @@ import { getDateRange } from 'lib/date';
 import DropDown from './DropDown';
 
 const filterOptions = [
-  { label: 'Last 24 hours', value: '24hour' },
-  { label: 'Last 7 days', value: '7day' },
-  { label: 'Last 30 days', value: '30day' },
-  { label: 'Last 90 days', value: '90day' },
   { label: 'Today', value: '1day' },
+  { label: 'Last 7 days', value: '7day' },
   { label: 'This week', value: '1week' },
+  { label: 'Last 30 days', value: '30day' },
   { label: 'This month', value: '1month' },
+  { label: 'Last 90 days', value: '90day' },
   { label: 'This year', value: '1year' },
 ];
 

--- a/lib/date.js
+++ b/lib/date.js
@@ -4,14 +4,12 @@ import {
   addHours,
   addDays,
   addMonths,
-  subHours,
   subDays,
   startOfHour,
   startOfDay,
   startOfWeek,
   startOfMonth,
   startOfYear,
-  endOfHour,
   endOfDay,
   endOfWeek,
   endOfMonth,
@@ -72,13 +70,6 @@ export function getDateRange(value) {
       return {
         startDate: subDays(startOfDay(now), num - 1),
         endDate: endOfDay(now),
-        unit,
-        value,
-      };
-    case 'hour':
-      return {
-        startDate: subHours(startOfHour(now), num - 1),
-        endDate: endOfHour(now),
         unit,
         value,
       };


### PR DESCRIPTION
It's confusing to find the intended date range right now because the dropdown isn't in ascending order of duration. This PR fixes that and also removes the **24 hours** option since nobody would generally use it with there being there a **Today** option already.

Please let me know if you have any suggestions!
