### PR TITLE
Use GitHub Container Registry for Docker images

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,7 @@
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - feat/push-to-github-container-registry
 
 jobs:
 
@@ -13,17 +14,29 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Build PostgreSQL container image
-      run: docker build --build-arg DATABASE_TYPE=postgresql --tag docker.pkg.github.com/mikecao/umami/umami:postgresql-$(echo $GITHUB_SHA | head -c7) .
+      run: | 
+        docker build --build-arg DATABASE_TYPE=postgresql \
+        --tag ghcr.io/$GITHUB_ACTOR/umami:postgresql-$(echo $GITHUB_SHA | head -c7) \
+        --tag ghcr.io/$GITHUB_ACTOR/umami:postgresql-latest \
+        .
 
     - name: Build MySQL container image
-      run: docker build --build-arg DATABASE_TYPE=mysql --tag docker.pkg.github.com/mikecao/umami/umami:mysql-$(echo $GITHUB_SHA | head -c7) .
+      run: |
+        docker build --build-arg DATABASE_TYPE=mysql \
+        --tag ghcr.io/$GITHUB_ACTOR/umami:mysql-$(echo $GITHUB_SHA | head -c7) \
+        --tag ghcr.io/$GITHUB_ACTOR/umami:mysql-latest \
+        .
 
     - name: Docker login
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: docker login -u mikecao -p $GITHUB_TOKEN docker.pkg.github.com
+        CR_PAT: ${{ secrets.CR_PAT }}
+      run: docker login -u $GITHUB_ACTOR -p $CR_PAT ghcr.io
       
     - name: Push image to GitHub
       run: |
-        docker push docker.pkg.github.com/mikecao/umami/umami:postgresql-$(echo $GITHUB_SHA | head -c7)
-        docker push docker.pkg.github.com/mikecao/umami/umami:mysql-$(echo $GITHUB_SHA | head -c7)
+        # Push each image individually, avoiding pushing to umami:latest
+        # as MySQL or PostgreSQL are required
+        docker push ghcr.io/$GITHUB_ACTOR/umami:postgresql-$(echo $GITHUB_SHA | head -c7)
+        docker push ghcr.io/$GITHUB_ACTOR/umami:postgresql-latest
+        docker push ghcr.io/$GITHUB_ACTOR/umami:mysql-$(echo $GITHUB_SHA | head -c7)
+        docker push ghcr.io/$GITHUB_ACTOR/umami:mysql-latest

--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ The `HASH_SALT` is used to generate unique values for your installation.
 
 ### Build the application
 
-```
+```bash
 npm run build
 ```
 
 ### Start the application
 
-```
+```bash
 npm start
 ```
 
@@ -78,15 +78,26 @@ or change the [port](https://nextjs.org/docs/api-reference/cli#production) to se
 
 To build the umami container and start up a Postgres database, run:
 
-```
+```bash
 docker-compose up
 ```
+
+Alternatively, to pull just the Umami Docker image with PostgreSQL support:
+```bash
+docker pull ghcr.io/mikecao/umami:postgresql-latest
+```
+
+Or with MySQL support:
+```bash
+docker pull ghcr.io/mikecao/umami:mysql-latest
+```
+
 
 ## Getting updates
 
 To get the latest features, simply do a pull, install any new dependencies, and rebuild:
 
-```
+```bash
 git pull
 npm install
 npm run build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3'
 services:
   umami:
-    build: .
+    image: ghcr.io/mikecao/umami:postgresql-latest
     ports:
       - "3000:3000"
     environment:


### PR DESCRIPTION
Closes #96.

### Changes
* Push Docker images to GHCR, as GHCR allows images to be pulled anonymously
* Update README to indicate how to pull just the Docker image
* Update `docker-compose.yml` to use the image from GitHub Container Registry instead of building the image

### Comments
* You can view an example of the Umami package (my fork) [here](https://github.com/users/hugomd/packages/container/umami/34767), which is listed on [my packages page](https://github.com/hugomd?tab=packages)
* [Here is a successful run of the GitHub Actions changes](https://github.com/hugomd/umami/runs/1077208675)

### Before Merging
Before merging:
* Create a new [GitHub Personal Access Token](https://github.com/settings/tokens/new), with `write:packages` and `read:packages` scopes.
* Setup a new secret, `CR_PAT` (Container Registry Personal Access Token). You can create a new one [here](https://github.com/mikecao/umami/settings/secrets/new), setting the personal access token as the value for the secret.