### PR TITLE
Add support for excluded and included domains

### DIFF
--- a/tracker/index.js
+++ b/tracker/index.js
@@ -17,6 +17,16 @@ import { removeTrailingSlash } from '../lib/url';
   // eslint-disable-next-line no-undef
   if (!script || (__DNT__ && doNotTrack())) return;
 
+  const excludedDomains = script.getAttribute('excluded-domains')
+    ? script.getAttribute('excluded-domains').split(',')
+    : [];
+  const allowedDomains = script.getAttribute('included-domains')
+    ? script.getAttribute('included-domains').split(',')
+    : [];
+  const isExcludedDomain = excludedDomains.includes(window.location.hostname);
+  const isAllowedDomain = allowedDomains.includes(window.location.hostname);
+  if (isExcludedDomain || !isAllowedDomain) return;
+
   const website = script.getAttribute('data-website-id');
   const hostUrl = script.getAttribute('data-host-url');
   const root = hostUrl


### PR DESCRIPTION
This PR adds support for the `excluded-domains` and `included-domains` attributes in the tracking script. By default, if these tags are not specified, the tracking script will work everywhere it's included. This feature is particularly useful for users who have multiple environments for local development or pre-production staging environments.

I can help with documenting this as well if this feature is accepted by the maintainers.

Closes #109
