### PR TITLE
Allow localhost:xxxx domains when adding websites

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -23,7 +23,7 @@ export const FILTER_DOMAIN_ONLY = 0;
 export const FILTER_COMBINED = 1;
 export const FILTER_RAW = 2;
 
-export const DOMAIN_REGEX = /localhost:\d{1,5}|((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,63}/;
+export const DOMAIN_REGEX = /localhost(:\d{1,5})?|((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,63}/;
 
 export const DESKTOP_SCREEN_WIDTH = 1920;
 export const LAPTOP_SCREEN_WIDTH = 1024;

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -23,7 +23,7 @@ export const FILTER_DOMAIN_ONLY = 0;
 export const FILTER_COMBINED = 1;
 export const FILTER_RAW = 2;
 
-export const DOMAIN_REGEX = /((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,63}/;
+export const DOMAIN_REGEX = /localhost:\d{1,5}|((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,63}/;
 
 export const DESKTOP_SCREEN_WIDTH = 1920;
 export const LAPTOP_SCREEN_WIDTH = 1024;


### PR DESCRIPTION
Fixes #172

This PR allows developers to add a website with a `localhost:xxxx` domain (e.g. `localhost:8080`)