### PR TITLE
Allow tracking to specify event types other than 'custom'

### DIFF
--- a/tracker/index.js
+++ b/tracker/index.js
@@ -104,6 +104,7 @@ import { removeTrailingSlash } from '../lib/url';
   pageView();
 
   if (!window.umami) {
-    window.umami = event_value => collect('event', { event_type: 'custom', event_value });
+    window.umami = (event_value, event_type = 'custom') =>
+      collect('event', { event_type, event_value });
   }
 })(window);


### PR DESCRIPTION
Fixes #174

This PR will change this line in [index.js](https://github.com/mikecao/umami/blob/master/tracker/index.js) 
`window.umami = event_value => collect('event', { event_type:'custom', event_value });`

to include a second value does not break current uses:
`window.umami = (event_value, event_type = 'custom') => collect('event', { event_type, event_value });`

Now a user can do, as normal e.g. `umami("remove:item:75")` which tracks as `{ event_type:'custom', event_value:"remove:item:75" }`

but also could do `umami("item:75", "remove")` which tracks as `{ event_type:'remove', event_value:'item:75' }`

