### PR TITLE
Fix 2 issues releated to the first time initialise umami

### DIFF
--- a/hooks/useDateRange.js
+++ b/hooks/useDateRange.js
@@ -12,8 +12,12 @@ export default function useDateRange(websiteId, defaultDateRange = '24hour') {
   } else {
     globalDateRange = {
       ...globalDefault,
-      startDate: parseISO(globalDefault.startDate),
-      endDate: parseISO(globalDefault.endDate),
+      startDate:
+        globalDefault && globalDefault.startDate
+          ? parseISO(globalDefault.startDate)
+          : new Date(Date.now() - 604800000),
+      endDate:
+        globalDefault && globalDefault.endDate ? parseISO(globalDefault.endDate) : new Date(),
     };
   }
 

--- a/hooks/useDateRange.js
+++ b/hooks/useDateRange.js
@@ -15,7 +15,7 @@ export default function useDateRange(websiteId, defaultDateRange = '24hour') {
       startDate:
         globalDefault && globalDefault.startDate
           ? parseISO(globalDefault.startDate)
-          : new Date(Date.now() - 604800000),
+          : new Date(Date.now() - 604800000), // set 7 days agao as default start date if no globalDefault
       endDate:
         globalDefault && globalDefault.endDate ? parseISO(globalDefault.endDate) : new Date(),
     };

--- a/lib/date.js
+++ b/lib/date.js
@@ -136,6 +136,10 @@ export function getDateArray(data, startDate, endDate, unit) {
 }
 
 export function getDateLength(startDate, endDate, unit) {
+  if (!unit) {
+    unit = 'day';
+  }
+
   const [diff] = dateFuncs[unit];
   return diff(endDate, startDate) + 1;
 }


### PR DESCRIPTION
I believe this issue only happen when a user install a new umami instance, but not upgrade from the old one.

it is like first time `globalDefault`, cannot be gotten through local storage, then `globalDefault.startDate` will throw an error and stop the app running.

