### PR TITLE
Trim Docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,39 @@
-FROM node:12.18-alpine
-
+# Build image
+FROM node:12.18-alpine AS build
 ARG DATABASE_TYPE
-
 ENV DATABASE_URL "postgresql://umami:umami@db:5432/umami" \
     DATABASE_TYPE=$DATABASE_TYPE
+WORKDIR /build
 
-WORKDIR /app
-EXPOSE 3000
+COPY package.json yarn.lock /build/
 
-COPY package.json yarn.lock /app/
-RUN yarn install --frozen-lockfile
+# Install only the production dependencies
+RUN yarn install --production
 
-COPY . /app
+# Cache these modules for production
+RUN cp -R node_modules/ prod_node_modules/
+
+# Install development dependencies
+RUN yarn install
+
+COPY . /build
 RUN yarn build
 
+# Production image
+FROM node:12.18-alpine AS production
+WORKDIR /app
+
+# Copy cached dependencies
+COPY --from=build /build/prod_node_modules ./node_modules
+
+# Copy generated Prisma client
+COPY --from=build /build/node_modules/\.prisma/ ./node_modules/\.prisma/
+
+COPY --from=build /build/yarn.lock /build/package.json ./
+COPY --from=build /build/.next ./.next
+COPY --from=build /build/public ./public
+
+USER node
+
+EXPOSE 3000
 CMD ["yarn", "start"]


### PR DESCRIPTION
Closes #204.

This change reduces the Docker image size from 1.18 GB to 429 MB 🤯 

# Changes
* Only copy production node dependencies into image.
* Use multi-stage build to make use of node dependency cache.
* Use non-root user, which is generally good practice and makes the running container effectively immutable.

# Comments
* Copying `node_modules` to `prod_node_modules` to cache them in the build step is pretty space expensive, but I don't see another way around it. This allows us to copy over only the production dependencies we need, and the alternative would be just running another `yarn install --production` in the release image.
* These changes were heavily inspired by [this post on dev.to](https://dev.to/chrsgrrtt/dockerising-a-next-js-project-1ck5)

Let me know if you have any questions or queries, or if you'd like me to push up a copy of this image to take for a spin before merging.

✌🏻 