### PR TITLE
Re-add usage of frozen lockfile when installing dependencies with yarn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,13 @@ WORKDIR /build
 COPY package.json yarn.lock /build/
 
 # Install only the production dependencies
-RUN yarn install --production
+RUN yarn install --frozen-lockfile
 
 # Cache these modules for production
 RUN cp -R node_modules/ prod_node_modules/
 
 # Install development dependencies
-RUN yarn install
+RUN yarn install --frozen-lockfile
 
 COPY . /build
 RUN yarn build
@@ -27,7 +27,7 @@ WORKDIR /app
 COPY --from=build /build/prod_node_modules ./node_modules
 
 # Copy generated Prisma client
-COPY --from=build /build/node_modules/\.prisma/ ./node_modules/\.prisma/
+COPY --from=build /build/node_modules/.prisma/ ./node_modules/.prisma/
 
 COPY --from=build /build/yarn.lock /build/package.json ./
 COPY --from=build /build/.next ./.next


### PR DESCRIPTION
I inadvertently removed `--frozen-lockfile` in #205.

### Changes
* Use `--frozen-lockfile` with `yarn install`
* Remove unnecessary escaping of `.` in `COPY`

### Testing
I've tested this locally and it seems to work as expected.

Thanks @tim-hub for raising this! (https://github.com/mikecao/umami/pull/205#discussion_r493428554)