### PR TITLE
Bind the node.js app to the port provided by Heroku 

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "npm-run-all build-tracker build-lang build-db build-app",
-    "start": "next start",
+    "start": "next start -p ${PORT-3000}",
     "build-app": "next build",
     "build-tracker": "rollup -c rollup.tracker.config.js",
     "build-db": "npm-run-all copy-db-schema build-db-client",


### PR DESCRIPTION
via the `$HOST` env var.

References:
- https://help.heroku.com/P1AVPANS/why-is-my-node-js-app-crashing-with-an-r10-error
- https://github.com/mikecao/umami/pull/135
- https://github.com/vercel/next.js/issues/10338