### PR TITLE
Translated missing german string

### DIFF
--- a/lang/de-DE.json
+++ b/lang/de-DE.json
@@ -65,7 +65,7 @@
   "message.get-tracking-code": "Erstelle Tracking Kennung",
   "message.go-to-settings": "Zu den Einstellungen",
   "message.incorrect-username-password": "Falsches Passwort oder Benutzername.",
-  "message.log.visitor": "Visitor from {country} using {browser} on {os} {device}",
+  "message.log.visitor": "Besucher aus {country} benutzt {browser} auf {os} {device}",
   "message.new-version-available": "Eine neue Version umami {version} ist verfügbar!",
   "message.no-data-available": "Keine Daten vorhanden.",
   "message.no-websites-configured": "Es ist keine Webseite vorhanden.",


### PR DESCRIPTION
Hi @mikecao,
recognised one missing German string in #297. Here it is. "Domains" is the same in German as in English.  