### PR TITLE
Added label.domain to german lang ignore list

### DIFF
--- a/scripts/lang-ignore.json
+++ b/scripts/lang-ignore.json
@@ -2,6 +2,7 @@
   "de-DE": [
     "label.administrator",
     "label.name",
+    "label.domain",
     "metrics.device.desktop",
     "metrics.device.laptop",
     "metrics.device.tablet",


### PR DESCRIPTION
"Domain" is the same in German as in English. 