### PR TITLE
Add Procfile to tell Heroku how to start the app

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: npm run start-env


### PR DESCRIPTION
Hi

Without a Procfile Heroku will use `npm start`. Usually good but in this case it doesn't take account of the process.env.PORT or HOSTNAME settings, so it won't bind correctly.

Thanks
Paul