### PR TITLE
WebsiteHeader title: fix mispelled CSS variable

### DIFF
--- a/components/metrics/WebsiteHeader.module.css
+++ b/components/metrics/WebsiteHeader.module.css
@@ -1,5 +1,5 @@
 .title {
-  color: var(--gray-900);
+  color: var(--gray900);
   font-size: var(--font-size-large);
   line-height: var(--font-size-large);
 }


### PR DESCRIPTION
Tiny fix.

It looks like the inherited `color` value was already `var(--gray900)` (from the `html, body` selector), so fixing this is not particularly useful.

Feel free to close this PR if you want to include the fix in other CSS changes.
