### PR TITLE
Remove decimals in bar chart y-axis

### DIFF
--- a/components/metrics/BarChart.js
+++ b/components/metrics/BarChart.js
@@ -175,6 +175,7 @@ export default function BarChart({
     options.scales.xAxes[0].ticks.callback = renderXLabel;
     options.scales.xAxes[0].ticks.fontColor = colors.text;
     options.scales.yAxes[0].ticks.fontColor = colors.text;
+    options.scales.yAxes[0].ticks.precision = 0;
     options.scales.yAxes[0].gridLines.color = colors.line;
     options.scales.yAxes[0].gridLines.zeroLineColor = colors.zeroLine;
     options.animation.duration = animationDuration;


### PR DESCRIPTION
While trying to investigate to fix bug #383 , I found that this happens to other bar chart also such as pageviews chart.
![image](https://user-images.githubusercontent.com/8341867/100152738-bbe21600-2ed5-11eb-8105-ddab70232efb.png)
So, I thought maybe we should make precision 0 on Y-Axis the default for bar chart to fix that too.
After this fix, they look like this:
**PageviewsChart**
![image](https://user-images.githubusercontent.com/8341867/100153248-6f4b0a80-2ed6-11eb-9b4c-c8fab58a98a2.png)
**EventsChart**
![image](https://user-images.githubusercontent.com/8341867/100153374-97d30480-2ed6-11eb-8ace-507056161a92.png)
