### PR TITLE
feat: allow blacklisting domains

### DIFF
--- a/tracker/index.js
+++ b/tracker/index.js
@@ -23,12 +23,25 @@ import { removeTrailingSlash } from '../lib/url';
   const dnt = attr('data-do-not-track');
   const useCache = attr('data-cache');
   const domains = attr('data-domains');
+  const domainBlacklist = attr('data-domains-blacklist');
 
+  /**
+   * blacklist has higher importance than whitelist,
+   * 
+   * i.e., if an item is both whitelisted and blacklisted,
+   * it will be blacklisted.
+   * 
+   */
   const disableTracking =
     localStorage.getItem('umami.disabled') ||
     (dnt && doNotTrack()) ||
     (domains &&
       !domains
+        .split(',')
+        .map(n => n.trim())
+        .includes(hostname)) ||
+    (domainBlacklist &&
+      domainBlacklist
         .split(',')
         .map(n => n.trim())
         .includes(hostname));


### PR DESCRIPTION
fixes https://github.com/mikecao/umami/issues/429

Need to discuss before merging:

1. we could change up the attribute name (maybe unify the "data-domains" to "data-domains-whitelist" while keeping backwards compatibility)

2. we can discuss the default of blacklisting vs whitelisting, but I think the current setup of blacklist being with higher priority is good (because by default, everything is whitelisted). Open for discussion though. 

3. updating docs