### PR TITLE
fix: typo error in 'KakaoTalk' constant

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -116,7 +116,7 @@ export const BROWSERS = {
   edge: 'Edge',
   'edge-ios': 'Edge (iOS)',
   yandexbrowser: 'Yandex',
-  kakaotalk: 'KKaoTalk',
+  kakaotalk: 'KaKaoTalk',
   samsung: 'Samsung',
   silk: 'Silk',
   miui: 'MIUI',


### PR DESCRIPTION
Shouldn't it be [Kakaotalk](https://www.kakaocorp.com/service/KakaoTalk?lang=en)?