### PR TITLE
Add on loadtest workflow

### DIFF
--- a/.github/workflows/actions-loadtest.yml
+++ b/.github/workflows/actions-loadtest.yml
@@ -1,0 +1,48 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Build and loadtest
+
+on:
+  push:
+    branches: [ dev ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: postgresql://umami:umami@localhost:5432/umami
+      DATABASE_TYPE: postgresql
+      HASH_SALT: ${{ github.sha }}
+
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: umami
+          POSTGRES_PASSWORD: umami
+          POSTGRES_DB: umami
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [14.x, 15.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Install schema
+      run: psql ${{ env.DATABASE_URL }} -f sql/schema.postgresql.sql &>/dev/null
+    - run: yarn install --non-interactive
+    - run: yarn build
+    - run: yarn start &
+    - run: yarn loadtest


### PR DESCRIPTION
I've been experimented with using SQLite as a backend db, and as a byproduct of that, I've created a workflow.
A load test using PostgreSQL as the backend db will be performed in GitHub Actions. (Other databases can also be support)

Please merge if you find it useful.
