### PR TITLE
Fix mobile rendering issues

### DIFF
--- a/components/layout/Header.module.css
+++ b/components/layout/Header.module.css
@@ -44,4 +44,7 @@
   .header {
     padding: 0 15px;
   }
+  .nav {
+    font-size: var(--font-size-normal);
+  }
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -36,6 +36,7 @@ export default function App({ Component, pageProps }) {
         <link rel="mask-icon" href="safari-pinned-tab.svg" color="#5bbad5" />
         <meta name="msapplication-TileColor" content="#da532c" />
         <meta name="theme-color" content="#ffffff" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
       </Head>
       <Intl>
         <Component {...pageProps} />


### PR DESCRIPTION
Addresses mikecao/umami#460

Adds an explicit meta tag for the viewport and resizes the navigation link size for smaller screens.

Result:
![image](https://user-images.githubusercontent.com/222221/107354349-e5492180-6a82-11eb-8346-f6c56eae2b16.png)
