### PR TITLE
Add sliding stats for mobile

### DIFF
--- a/components/metrics/MetricsBar.module.css
+++ b/components/metrics/MetricsBar.module.css
@@ -11,8 +11,6 @@
 @media only screen and (max-width: 992px) {
   .bar {
     justify-content: space-between;
-  }
-  .bar > div:nth-child(n + 3) {
-    display: none;
+    overflow: auto;
   }
 }


### PR DESCRIPTION
Currently 2 out of the 4 card stats are hidden on mobile. This 2 line CSS fix adds a native slider (that is, no JS fanciness) that only shows when content is hidden, allowing for easy access to said stats.

![slidingStats](https://user-images.githubusercontent.com/7612764/107703917-3cace480-6c71-11eb-914a-41d0a9e208ec.gif)
