### PR TITLE
Dashboard: Dropdown for filtering events by their type

### DIFF
--- a/components/metrics/EventsTable.js
+++ b/components/metrics/EventsTable.js
@@ -13,7 +13,7 @@ import styles from './EventsTable.module.css';
 
 const EVENT_FILTER_DEFAULT = {
   value: 'EVENT_FILTER_DEFAULT',
-  label: 'All Events',
+  label: <FormattedMessage id="label.all-events" defaultMessage="All events" />,
 };
 
 export default function EventsTable({ websiteId, ...props }) {

--- a/components/metrics/EventsTable.js
+++ b/components/metrics/EventsTable.js
@@ -1,18 +1,65 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import MetricsTable from './MetricsTable';
 import Tag from 'components/common/Tag';
+import DropDown from 'components/common/DropDown';
+import { eventTypeFilter } from 'lib/filters';
+import useDateRange from 'hooks/useDateRange';
+import useFetch from 'hooks/useFetch';
+import usePageQuery from 'hooks/usePageQuery';
+import useShareToken from 'hooks/useShareToken';
+import { TOKEN_HEADER } from 'lib/constants';
+
+const EVENT_FILTER_DEFAULT = {
+  value: 'EVENT_FILTER_DEFAULT',
+  label: 'All Events',
+};
 
 export default function EventsTable({ websiteId, ...props }) {
+  const [eventType, setEventType] = useState(EVENT_FILTER_DEFAULT.value);
+
+  const {
+    query: { url },
+  } = usePageQuery();
+
+  const shareToken = useShareToken();
+  const [dateRange] = useDateRange(websiteId);
+
+  const { startDate, endDate, modified } = dateRange;
+  const { data, loading, error } = useFetch(
+    `/api/website/${websiteId}/event-types`,
+    {
+      params: {
+        start_at: +startDate,
+        end_at: +endDate,
+        url,
+      },
+      headers: { [TOKEN_HEADER]: shareToken?.token },
+    },
+    [modified],
+  );
+
+  const eventTypes = data ? [...new Set(data.map(({ x }) => x))] : [];
+  const dropDownOptions = [EVENT_FILTER_DEFAULT, ...eventTypes.map(t => ({ value: t, label: t }))];
+
   return (
-    <MetricsTable
-      {...props}
-      title={<FormattedMessage id="metrics.events" defaultMessage="Events" />}
-      type="event"
-      metric={<FormattedMessage id="metrics.actions" defaultMessage="Actions" />}
-      websiteId={websiteId}
-      renderLabel={({ x }) => <Label value={x} />}
-    />
+    <>
+      {!loading && !error && eventTypes.length > 1 && (
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+          <DropDown value={eventType} options={dropDownOptions} onChange={setEventType} />
+        </div>
+      )}
+      <MetricsTable
+        {...props}
+        title={<FormattedMessage id="metrics.events" defaultMessage="Events" />}
+        type="event"
+        metric={<FormattedMessage id="metrics.actions" defaultMessage="Actions" />}
+        websiteId={websiteId}
+        dataFilter={eventTypeFilter}
+        filterOptions={eventType === EVENT_FILTER_DEFAULT.value ? [] : [eventType]}
+        renderLabel={({ x }) => <Label value={x} />}
+      />
+    </>
   );
 }
 

--- a/components/metrics/EventsTable.js
+++ b/components/metrics/EventsTable.js
@@ -9,6 +9,7 @@ import useFetch from 'hooks/useFetch';
 import usePageQuery from 'hooks/usePageQuery';
 import useShareToken from 'hooks/useShareToken';
 import { TOKEN_HEADER } from 'lib/constants';
+import styles from './EventsTable.module.css';
 
 const EVENT_FILTER_DEFAULT = {
   value: 'EVENT_FILTER_DEFAULT',
@@ -45,7 +46,7 @@ export default function EventsTable({ websiteId, ...props }) {
   return (
     <>
       {!loading && !error && eventTypes.length > 1 && (
-        <div style={{ display: 'flex', alignItems: 'center' }}>
+        <div className={styles.filter}>
           <DropDown value={eventType} options={dropDownOptions} onChange={setEventType} />
         </div>
       )}

--- a/components/metrics/EventsTable.module.css
+++ b/components/metrics/EventsTable.module.css
@@ -1,0 +1,6 @@
+.filter {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  margin-bottom: 15px;
+}

--- a/lang/de-DE.json
+++ b/lang/de-DE.json
@@ -5,6 +5,7 @@
   "label.administrator": "Administrator",
   "label.all": "Alle",
   "label.all-websites": "Alle Webseiten",
+  "label.all-events": "Alle Ereignisse",
   "label.back": "Zurück",
   "label.cancel": "Abbrechen",
   "label.change-password": "Passwort ändern",

--- a/lang/en-US.json
+++ b/lang/en-US.json
@@ -5,6 +5,7 @@
   "label.administrator": "Administrator",
   "label.all": "All",
   "label.all-websites": "All websites",
+  "label.all-events": "All events",
   "label.back": "Back",
   "label.cancel": "Cancel",
   "label.change-password": "Change password",

--- a/lang/es-MX.json
+++ b/lang/es-MX.json
@@ -5,6 +5,7 @@
   "label.administrator": "Administrador",
   "label.all": "Todos",
   "label.all-websites": "Todos los sitios",
+  "label.all-events": "Todos los eventos",
   "label.back": "Atrás",
   "label.cancel": "Cancelar",
   "label.change-password": "Cambiar contraseña",

--- a/lang/fr-FR.json
+++ b/lang/fr-FR.json
@@ -5,6 +5,7 @@
   "label.administrator": "Administrateur",
   "label.all": "Tout",
   "label.all-websites": "Tous les sites web",
+  "label.all-events": "Tous les événements",
   "label.back": "Retour",
   "label.cancel": "Annuler",
   "label.change-password": "Changer le mot de passe",

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -113,6 +113,17 @@ export const refFilter = (data, { domain, domainOnly, raw }) => {
   return Object.keys(map).map(key => ({ x: key, y: map[key], w: links[key] }));
 };
 
+export const eventTypeFilter = (data, types) => {
+  if (!types || types.length === 0) {
+    return data;
+  }
+
+  return data.filter(({ x }) => {
+    const [event] = x.split('\t');
+    return types.some(type => type === event);
+  });
+};
+
 export const browserFilter = data =>
   data.map(({ x, y }) => ({ x: BROWSERS[x] || x, y })).filter(({ x }) => x);
 

--- a/lib/queries.js
+++ b/lib/queries.js
@@ -501,6 +501,41 @@ export function getEventMetrics(
   );
 }
 
+export function getEventTypes(
+  website_id,
+  start_at,
+  end_at,
+  timezone = 'utc',
+  unit = 'day',
+  filters = {},
+) {
+  const params = [website_id, start_at, end_at];
+  const { url } = filters;
+
+  let urlFilter = '';
+
+  if (url) {
+    urlFilter = `and url=$${params.length + 1}`;
+    params.push(decodeURIComponent(url));
+  }
+
+  return rawQuery(
+    `
+    select
+      event_type x,
+      ${getDateQuery('created_at', unit, timezone)} t,
+      count(*) y
+    from event
+    where website_id=$1
+    and created_at between $2 and $3
+    ${urlFilter}
+    group by 1, 2
+    order by 2
+    `,
+    params,
+  );
+}
+
 export async function getRealtimeData(websites, time) {
   const [pageviews, sessions, events] = await Promise.all([
     getPageviews(websites, time),

--- a/pages/api/website/[id]/event-types.js
+++ b/pages/api/website/[id]/event-types.js
@@ -1,0 +1,25 @@
+import { getEventTypes } from 'lib/queries';
+import { ok, methodNotAllowed, unauthorized } from 'lib/response';
+import { allowQuery } from 'lib/auth';
+
+export default async (req, res) => {
+  if (req.method === 'GET') {
+    if (!(await allowQuery(req))) {
+      return unauthorized(res);
+    }
+
+    const { id, start_at, end_at, url } = req.query;
+
+    const websiteId = +id;
+    const startDate = new Date(+start_at);
+    const endDate = new Date(+end_at);
+
+    const eventTypes = await getEventTypes(websiteId, startDate, endDate, undefined, undefined, {
+      url,
+    });
+
+    return ok(res, eventTypes);
+  }
+
+  return methodNotAllowed(res);
+};


### PR DESCRIPTION
Add dropdown to the dashboard for filtering events by their type. It is only displayed, when multiple types of events are present.

This pull request closes issue https://github.com/mikecao/umami/issues/466

Translation for following languages included:
* 🇺🇸 English
* 🇩🇪 German
* 🇪🇸 Spanish
* 🇫🇷 French

<img width="375" alt="Screenshot 2021-02-15 at 18 17 24" src="https://user-images.githubusercontent.com/24435169/107977277-2083ad00-6fbb-11eb-9daf-aec5dc921713.png"> <img width="373" alt="Screenshot 2021-02-15 at 18 17 59" src="https://user-images.githubusercontent.com/24435169/107977289-22e60700-6fbb-11eb-9d13-fe289eb6d8f1.png">