### PR TITLE
Timestamp localization

### DIFF
--- a/components/metrics/BarChart.js
+++ b/components/metrics/BarChart.js
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import ChartJS from 'chart.js';
 import Legend from 'components/metrics/Legend';
 import { formatLongNumber } from 'lib/format';
-import { dateFormat } from 'lib/lang';
+import { dateFormat, timeFormat } from 'lib/lang';
 import useLocale from 'hooks/useLocale';
 import useTheme from 'hooks/useTheme';
 import { DEFAUL_CHART_HEIGHT, DEFAULT_ANIMATION_DURATION, THEME_COLORS } from 'lib/constants';
@@ -46,7 +46,7 @@ export default function BarChart({
       case 'minute':
         return index % 2 === 0 ? dateFormat(d, 'h:mm', locale) : '';
       case 'hour':
-        return dateFormat(d, 'ha', locale);
+        return timeFormat(d, locale);
       case 'day':
         if (records > 31) {
           if (w <= 500) {
@@ -131,6 +131,7 @@ export default function BarChart({
               minRotation: 0,
               maxRotation: 0,
               fontColor: colors.text,
+              autoSkipPadding: 1,
             },
             gridLines: {
               display: false,

--- a/lib/lang.js
+++ b/lib/lang.js
@@ -118,6 +118,11 @@ export const dateLocales = {
   'it-IT': it,
 };
 
+const timeFormats = {
+  // https://date-fns.org/v2.17.0/docs/format
+  'en-US': 'ha',
+};
+
 export const menuOptions = [
   { label: '中文', value: 'zh-CN', display: 'cn' },
   { label: '中文(繁體)', value: 'zh-TW', display: 'tw' },
@@ -151,4 +156,8 @@ export const menuOptions = [
 
 export function dateFormat(date, str, locale) {
   return format(date, str, { locale: dateLocales[locale] || enUS });
+}
+
+export function timeFormat(date, locale = 'en-US') {
+  return format(date, timeFormats[locale] || 'p', { locale: dateLocales[locale] });
 }


### PR DESCRIPTION
This PR is based on issue #483 and #193.

It adds localized timestamp underneath the different BarCharts by using the date-fns `format()` function. This defaults to `p`, the localized format, and other formats can be set per locale. For example, `en-US` will keep the current default of `ha`. If no locale is set, the en-US format will be used.

In order to fix some visual bugs with almost overlapping labels underneath the BarChart showing events, `autoSkipPadding: 1` has been added to the options of Chart.js. This will cause Chart.js to more frequently 'skip' a label to preserve readability. The precise timestamp can still be seen in the tooltip by hovering over the bars itself.

Regarding this tooltip, I haven't provided a way to localize these yet. This would probably necessitate some slight refactoring of `lib/lang.js` and/or `getTooltipFormat()` in `components/metrics/BarChart.js`.