### PR TITLE
Fix: domain regex accepting invalid domains

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -80,7 +80,7 @@ export const POSTGRESQL_DATE_FORMATS = {
   year: 'YYYY-01-01',
 };
 
-export const DOMAIN_REGEX = /localhost(:\d{1,5})?|((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,63}/;
+export const DOMAIN_REGEX = /^localhost(:\d{1,5})?|((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,63}$/;
 
 export const DESKTOP_SCREEN_WIDTH = 1920;
 export const LAPTOP_SCREEN_WIDTH = 1024;


### PR DESCRIPTION
Change the domain regex to match the whole string.
Before, the regex would accept a string if it contained a valid domain at any point.

This closes issue https://github.com/mikecao/umami/issues/479