### PR TITLE
fix: event table fails to render in detail view

### DIFF
--- a/components/metrics/EventsTable.js
+++ b/components/metrics/EventsTable.js
@@ -19,7 +19,7 @@ export default function EventsTable({ websiteId, ...props }) {
 
   function handleDataLoad(data) {
     setEventTypes([...new Set(data.map(({ x }) => x.split('\t')[0]))]);
-    props.onDataLoad(data);
+    props.onDataLoad?.(data);
   }
 
   return (


### PR DESCRIPTION
The `EventsTable` component failed to render in the detail view, because the `onDataLoad` property is called but none was provided. See the issue for details.

Add a nullcheck to `onDataLoad` before calling it.

Refs #495