### PR TITLE
fix(api): reject all metrics requests for invalid domains

### DIFF
--- a/pages/api/website/[id]/metrics.js
+++ b/pages/api/website/[id]/metrics.js
@@ -33,7 +33,7 @@ export default async (req, res) => {
 
     const { id, type, start_at, end_at, domain, url } = req.query;
 
-    if (domain && !DOMAIN_REGEX.test(domain)) {
+    if (type === 'referrer' && domain && !DOMAIN_REGEX.test(domain)) {
       return badRequest(res);
     }
 


### PR DESCRIPTION
Add check for requested metric type before domain name check.
Only the referrer metrics use the domain name; all other metrics should be unaffected.

This pull requests partially closes issue #503.