### PR TITLE
Display descriptive error message on invalid domain error.

### DIFF
--- a/components/common/ErrorMessage.js
+++ b/components/common/ErrorMessage.js
@@ -1,14 +1,27 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import Icon from './Icon';
 import Exclamation from 'assets/exclamation-triangle.svg';
 import styles from './ErrorMessage.module.css';
 
-export default function ErrorMessage() {
+const DEFAULT_ID = 'message.failure';
+const DEFAULT_MESSAGE = 'Something went wrong';
+
+function ErrorMessage({ error }) {
+  const [id, defaultMessage] =
+    typeof error === 'string' ? error.split('\t') : [DEFAULT_ID, DEFAULT_MESSAGE];
+
   return (
     <div className={styles.error}>
       <Icon icon={<Exclamation />} className={styles.icon} size="large" />
-      <FormattedMessage id="message.failure" defaultMessage="Something went wrong." />
+      <FormattedMessage id={id} defaultMessage={defaultMessage} />
     </div>
   );
 }
+
+ErrorMessage.propTypes = {
+  error: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Error)]),
+};
+
+export default ErrorMessage;

--- a/components/metrics/MetricsTable.js
+++ b/components/metrics/MetricsTable.js
@@ -66,7 +66,7 @@ export default function MetricsTable({
   return (
     <div className={classNames(styles.container, className)}>
       {!data && loading && <Loading />}
-      {error && <ErrorMessage />}
+      {error && <ErrorMessage error={error} />}
       {data && !error && <DataTable {...props} data={filteredData} className={className} />}
       <div className={styles.footer}>
         {data && !error && limit && (

--- a/lang/de-DE.json
+++ b/lang/de-DE.json
@@ -1,4 +1,5 @@
 {
+  "error.bad-domain": "Ungültige Domain. Bitte Einstellungen überprüfen.",
   "label.accounts": "Konten",
   "label.add-account": "Konto hinzugfügen",
   "label.add-website": "Webseite hinzufügen",

--- a/lang/en-US.json
+++ b/lang/en-US.json
@@ -1,4 +1,5 @@
 {
+  "error.bad-domain": "Invalid domain name. Please check settings.",
   "label.accounts": "Accounts",
   "label.add-account": "Add account",
   "label.add-website": "Add website",

--- a/lang/es-MX.json
+++ b/lang/es-MX.json
@@ -1,4 +1,5 @@
 {
+  "error.bad-domain": "Dominio inválido. Por favor revisar configuraciones.",
   "label.accounts": "Usuarios",
   "label.add-account": "Agregar usuario",
   "label.add-website": "Agregar sitio",

--- a/pages/api/website/[id]/metrics.js
+++ b/pages/api/website/[id]/metrics.js
@@ -34,7 +34,7 @@ export default async (req, res) => {
     const { id, type, start_at, end_at, domain, url } = req.query;
 
     if (domain && !DOMAIN_REGEX.test(domain)) {
-      return badRequest(res, 'error.bad-domain\tInvalid domain name - please check settings');
+      return badRequest(res, 'error.bad-domain\tInvalid domain name. Please check settings.');
     }
 
     const websiteId = +id;

--- a/pages/api/website/[id]/metrics.js
+++ b/pages/api/website/[id]/metrics.js
@@ -34,7 +34,7 @@ export default async (req, res) => {
     const { id, type, start_at, end_at, domain, url } = req.query;
 
     if (domain && !DOMAIN_REGEX.test(domain)) {
-      return badRequest(res);
+      return badRequest(res, 'error.bad-domain\tInvalid domain name - please check settings');
     }
 
     const websiteId = +id;


### PR DESCRIPTION
Display descriptive error message in dashboard, when website has invalid domain name in settings. Displaying descriptive errors helps users find solutions to their problems themselves (see #505)

* API returns descriptive error message on domain name mismatch when fetching website metrics.
* Add ability to parse error to `ErrorMessage` component.

Translations added for English, German and Spanish.