### PR TITLE
Updated docker-compose for persistent pgsql volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,6 @@ services:
       POSTGRES_PASSWORD: umami
     volumes:
       - ./sql/schema.postgresql.sql:/docker-entrypoint-initdb.d/schema.postgresql.sql:ro
-      - umami-db-data:/var/lib/postgresql/data
+      - ./umami-db-data:/var/lib/postgresql/data
 volumes:
   umami-db-data:


### PR DESCRIPTION
There was a typo and the db data storage wasn't being created, in this way it is created in the same folder as the docker-compose.yml file.