### PR TITLE
Style: Add gap between "empty" placeholder message and children

### DIFF
--- a/components/common/EmptyPlaceholder.js
+++ b/components/common/EmptyPlaceholder.js
@@ -8,7 +8,7 @@ function EmptyPlaceholder({ msg, children }) {
   return (
     <div className={styles.placeholder}>
       <Icon className={styles.icon} icon={<Logo />} size="xlarge" />
-      <h2>{msg}</h2>
+      <h2 className={styles.msg}>{msg}</h2>
       {children}
     </div>
   );

--- a/components/common/EmptyPlaceholder.module.css
+++ b/components/common/EmptyPlaceholder.module.css
@@ -9,3 +9,7 @@
 .icon {
   margin-bottom: 30px;
 }
+
+.msg {
+  margin-bottom: 15px;
+}


### PR DESCRIPTION
Nothing much to say, just noticed it and wanted to share (maybe fix): There's a missing margin between the message of the `EmptyPlaceholder` component and it's children.

The following are before-after screenshots of this PR.

`/settings`

<img height=150 src="https://user-images.githubusercontent.com/24435169/110974697-14430380-835f-11eb-8db2-9cb57b94edd4.png"> <img height=150 src="https://user-images.githubusercontent.com/24435169/110974703-160cc700-835f-11eb-88eb-f2821ce71580.png">

`/dashboard`

<img height=150 src="https://user-images.githubusercontent.com/24435169/110974649-08574180-835f-11eb-9a5c-c64cd8a618c5.png"> <img height=150 src="https://user-images.githubusercontent.com/24435169/110974656-0a210500-835f-11eb-9a3f-5177a0291956.png">