### PR TITLE
Use `GITHUB_TOKEN` for publishing images to GHCR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,9 +28,9 @@ jobs:
         .
 
     - name: Docker login
-      env:
-        CR_PAT: ${{ secrets.CR_PAT }}
-      run: docker login -u $GITHUB_ACTOR -p $CR_PAT ghcr.io
+      run: >-
+        echo "${{ secrets.GITHUB_TOKEN }}"
+        | docker login -u "${{ github.actor }}" --password-stdin
       
     - name: Push image to GitHub
       run: |


### PR DESCRIPTION
Hey @mikecao,

FYI GH just improved the privilege model of the GHCR+GITHUB_TOKEN secret combo five days ago: https://github.blog/changelog/2021-03-24-packages-container-registry-now-supports-github_token/.

This means that it is now possible to use `GITHUB_TOKEN` to improve the container image publishing security (because `GITHUB_TOKEN` is resource- and time-scoped as opposed to a personal access token which is not limited in time or accessing any repos/orgs your account has access to).

I've verified that this new way actually works in my repo:

- https://github.com/ansible/pylibssh/commit/c116938
- https://github.com/ansible/pylibssh/commit/c1169384ee78a9d34e4e012ad32b6238fb8cbace/checks
- and also verified on another repo @ https://github.com/pyca/infra/pull/346 / https://github.com/pyca/infra/issues/343

How to migrate?
---------------

1) Go to each image page `Package settings` -> `Action access` tab. Or click https://github.com/users/mikecao/packages/container/umami/settings/actions_access
2) Click `Add repository` -> type in `umami`, select it.
3) **ONLY AFTER THE PREVIOUS STEPS** merge this PR (this is not the first step to ensure you grant the access first).
4) Remove `CR_PAT` from https://github.com/mikecao/umami/settings/secrets/actions.
5) Delete this token however it's called from your personal user (or bot?) account at https://github.com/settings/tokens