### PR TITLE
Align and theme mobile burger button

### DIFF
--- a/components/layout/Header.module.css
+++ b/components/layout/Header.module.css
@@ -70,6 +70,11 @@
     padding: 0 15px;
   }
 
+  .title {
+    padding: 0.5rem;
+    margin-bottom: 0.5rem;
+  }
+
   .nav {
     font-size: var(--font-size-normal);
     flex-wrap: wrap;

--- a/components/layout/Header.module.css
+++ b/components/layout/Header.module.css
@@ -102,6 +102,9 @@
   .burger {
     display: block;
     /* color: #4a4a4a; */
+    background: none;
+    border: 1px solid var(--gray900);
+    border-radius: 4px;
     cursor: pointer;
     height: 3.25rem;
     width: 3.25rem;
@@ -112,20 +115,20 @@
   }
 
   .burger span {
-    transform: translateX(-50%);
+    transform: translateX(25%);
     padding: 1px 0px;
     margin: 6px 0;
-    width: 20px;
+    width: 65%;
     display: block;
-    background-color: white;
+    background-color: var(--gray900);
   }
 
   .burger div {
-    height: 100%;
-    color: white;
+    /* height: 100%; */
+    color: var(--gray900);
     text-align: center;
     margin: auto;
     font-size: 1.5rem;
-    transform: translateX(-50%);
+    /* transform: translateX(-50%); */
   }
 }


### PR DESCRIPTION
This aligns the burger button's contents, prevents it from overlapping menu items, and matches its color to the set theme.

### Before:
<img src="https://user-images.githubusercontent.com/22360092/112977249-d0ece100-9123-11eb-9655-b0ff5f550b52.png" width="50%" height="50%"><img src="https://user-images.githubusercontent.com/22360092/112977260-d34f3b00-9123-11eb-8ff3-b1557b456c1d.png" width="50%" height="50%"><img src="https://user-images.githubusercontent.com/22360092/112977272-d6e2c200-9123-11eb-9da8-ddf307668fb3.png" width="50%" height="50%"><img src="https://user-images.githubusercontent.com/22360092/112977279-d8ac8580-9123-11eb-9cb4-3a79b526befb.png" width="50%" height="50%">

### After:
<img src="https://user-images.githubusercontent.com/22360092/112977292-dd713980-9123-11eb-9471-f2b7f4c45528.png" width="50%" height="50%"><img src="https://user-images.githubusercontent.com/22360092/112977295-df3afd00-9123-11eb-824e-c9ea1825b70a.png" width="50%" height="50%"><img src="https://user-images.githubusercontent.com/22360092/112977301-e19d5700-9123-11eb-979a-225c861837b3.png" width="50%" height="50%"><img src="https://user-images.githubusercontent.com/22360092/112977308-e3671a80-9123-11eb-94c5-53e1edbb6c7e.png" width="50%" height="50%">
