### PR TITLE
geo db  load 1 time

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -49,6 +49,24 @@ export function getDevice(screen, browser, os) {
   }
 }
 
+let lookupGeo;
+let loadingPromise;
+// load geo db only 1 time
+async function loadGeo() {
+  if (lookupGeo) return lookupGeo;
+  if (loadingPromise) return loadingPromise;
+  loadingPromise = new Promise((resolve, reject) =>
+    maxmind
+      .open(path.resolve('./public/geo/GeoLite2-Country.mmdb'))
+      .then(res => {
+        lookupGeo = res;
+        resolve(lookupGeo);
+      })
+      .catch(reject),
+  );
+  return loadingPromise;
+}
+
 export async function getCountry(req, ip) {
   // Cloudflare
   if (req.headers['cf-ipcountry']) {
@@ -61,7 +79,7 @@ export async function getCountry(req, ip) {
   }
 
   // Database lookup
-  const lookup = await maxmind.open(path.resolve('./public/geo/GeoLite2-Country.mmdb'));
+  const lookup = await loadGeo();
 
   const result = lookup.get(ip);
 


### PR DESCRIPTION
geo db loaded on every request => now load only 1 time

this patch reduced CPU load by 3x for docker use(no serverless)
![image](https://user-images.githubusercontent.com/17857776/114527227-64f49780-9c50-11eb-94f1-3ff21c8df5b4.png)

I also used the base by cities(i save also cities), not countries, but I think the main effect is due to loading 1 time
if you use the city base without this patch, the docker dies by OOM



