### PR TITLE
Fix Pages filter when URL has a trailing slash

### DIFF
--- a/lib/filters.js
+++ b/lib/filters.js
@@ -18,7 +18,7 @@ export const urlFilter = (data, { raw }) => {
         return `${pathname}${search}`;
       }
 
-      return removeTrailingSlash(pathname);
+      return pathname;
     } catch {
       return null;
     }


### PR DESCRIPTION
This fixes https://github.com/mikecao/umami/issues/606 as discussed there. It's not uncommon for URLs to have a trailing slash and this format is used for instance by Ghost CMS; thus it can cause issues with the way Umami clears URLs for its filtering function (requests do not have a trailing slash so they return empty results).

Tried this (very) small change myself and everything seems fine!

EDIT: After some thinking I think it was there in the first place to prevent mixing up trail & non-trail URLs. Normally this shouldn't be an issue as it should be properly handled by the website itself (in case of Ghost, it redirects non-slash to slash).

Don't hesitate to close this PR if you think there's a better way to handle this:
- For instance, Umami could become "slash agnostic" and return results for **both** slash & non-slash
- But now it's defaulting to non-slash, which breaks page filter for some of us