### PR TITLE
prevents crashes if NULL is entered as a referrer in the database

### DIFF
--- a/lib/filters.js
+++ b/lib/filters.js
@@ -51,7 +51,7 @@ export const refFilter = (data, { domain, domainOnly, raw }) => {
   const links = {};
 
   const isValidRef = ref => {
-    return ref !== '' && !ref.startsWith('/') && !ref.startsWith('#');
+    return ref !== '' && ref !== null && !ref.startsWith('/') && !ref.startsWith('#');
   };
 
   if (raw) {


### PR DESCRIPTION
- Prevents crashes if NULL is entered as a referrer in the database.
- Does not guard against submitting NULL to the database.