### PR TITLE
Enhancement of issue #649: also checking agains NULL in urlFilter

### DIFF
--- a/lib/filters.js
+++ b/lib/filters.js
@@ -3,7 +3,7 @@ import { removeTrailingSlash, removeWWW, getDomainName } from './url';
 
 export const urlFilter = (data, { raw }) => {
   const isValidUrl = url => {
-    return url !== '' && !url.startsWith('#');
+    return url !== '' && url !== null && !url.startsWith('#');
   };
 
   if (raw) {


### PR DESCRIPTION
PR #650 implements checking agains _null_ in **ref**Filter to prevent crashes in the detailed view of the dashboard. In referrer urls using null within tracking function should be a legal operation an so DB also allows _null_ values (which in my opinion is good).

**url**Filter checks urls which aren't even allowed to be a _null_ value within the DB (which in my opinion is also good, because otherwise it doesn't make such much sense to submit an tracking url), however, this potential bug should also be closed for any future changes. Otherwise this could also lead to crashes of the dashboard.