### PR TITLE
Fix mismatching background in dark mode overscroll

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -12,9 +12,12 @@ body {
   flex: 1;
 
   font-size: var(--font-size-normal);
+  overflow-y: overlay;
+}
+
+body {
   color: var(--gray900);
   background: var(--gray75);
-  overflow-y: overlay;
 }
 
 .zh-CN {


### PR DESCRIPTION
In macOS and iOS devices you can scroll past the body. When this happens
in dark mode, the css variables are only changed from the `body`, and
the ones used in `html` are not changed. This causes the overscroll
background to be displayed as the light mode color.

Before:
![2021-05-22 21 50 50](https://user-images.githubusercontent.com/1889213/119239351-c4e03700-bb48-11eb-9862-d5e07a7b738f.gif)

After:
![2021-05-22 21 48 52](https://user-images.githubusercontent.com/1889213/119239356-ca3d8180-bb48-11eb-9e83-441a55ae3f58.gif)
