### PR TITLE
hide the chart when view other tab

### DIFF
--- a/components/pages/WebsiteDetails.js
+++ b/components/pages/WebsiteDetails.js
@@ -108,7 +108,7 @@ export default function WebsiteDetails({ websiteId }) {
 
   return (
     <Page>
-      <div className="row">
+      <div className={classNames('row', {[styles.hidden]: !!view })}>
         <div className={classNames(styles.chart, 'col')}>
           <WebsiteChart
             websiteId={websiteId}


### PR DESCRIPTION
At the website details page, when click the "Pages", "Referrers" etc. button, will go to the view page, but after click the another button, page scroll to top, the default show is the main chart, not the details I want, so by default hide the chart when I click the buttons "Pages"", "Referrers" etc