### PR TITLE
Consider adding restart policy to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       HASH_SALT: replace-me-with-a-random-string
     depends_on:
       - db
+    restart: always
   db:
     image: postgres:12-alpine
     environment:
@@ -20,5 +21,6 @@ services:
     volumes:
       - ./sql/schema.postgresql.sql:/docker-entrypoint-initdb.d/schema.postgresql.sql:ro
       - umami-db-data:/var/lib/postgresql/data
+    restart: always
 volumes:
   umami-db-data:


### PR DESCRIPTION
It might be a good idea to add a restart policy to the default `docker-compose.yml` file.

Either: `restart: always` or `restart: unless-stopped`

Useful in case Umami crashes for some reason (see #721)

This is also useful in case the server restarts, so Umami starts up again after rebooting.

https://docs.docker.com/config/containers/start-containers-automatically/