### PR TITLE
Ensure comparaison of same CIDR IP version

### DIFF
--- a/pages/api/collect.js
+++ b/pages/api/collect.js
@@ -24,7 +24,7 @@ export default async (req, res) => {
         const addr = ipaddr.parse(ip);
         const range = ipaddr.parseCIDR(i);
 
-        if (addr.match(range)) return true;
+        if (addr.kind() === range[0].kind() && addr.match(range)) return true;
       }
 
       return false;


### PR DESCRIPTION
Hi! and thanks for this awesome project!

Since the implementation of #544, I got the following issue when someone POST to `/api/collect`:

```
Error: ipaddr: cannot match ipv6 address with non-ipv6 one
    at IPv6.ipaddr.IPv6.IPv6.match (/app/node_modules/ipaddr.js/lib/ipaddr.js:572:23)
    at /app/.next/server/pages/api/collect.js:169:18
    at Array.find (<anonymous>)
    at module.exports.FVZN.__webpack_exports__.default (/app/.next/server/pages/api/collect.js:163:25)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async apiResolver (/app/node_modules/next/dist/next-server/server/api-utils.js:8:1)
    at async Server.handleApiRequest (/app/node_modules/next/dist/next-server/server/next-server.js:66:462)
    at async Object.fn (/app/node_modules/next/dist/next-server/server/next-server.js:58:580)
    at async Router.execute (/app/node_modules/next/dist/next-server/server/router.js:25:67)
```

In fact, my visitors come with an IPv6 and Umami tries to match against an IPv4 CIDR in IGNORE_IP list. I imagine the same is true with IPv4 visitor and IPv6 CIDR.

I propose this fix that avoid doing the match if the visitor IP and the range IP types differs.