### PR TITLE
Add time period comparison metric to dashboard

### DIFF
--- a/components/metrics/MetricCard.js
+++ b/components/metrics/MetricCard.js
@@ -3,13 +3,38 @@ import { useSpring, animated } from 'react-spring';
 import { formatNumber } from '../../lib/format';
 import styles from './MetricCard.module.css';
 
-const MetricCard = ({ value = 0, label, format = formatNumber }) => {
+const MetricCard = ({
+  value = 0,
+  change = 0,
+  label,
+  reverseColors = false,
+  format = formatNumber,
+}) => {
   const props = useSpring({ x: Number(value) || 0, from: { x: 0 } });
+  const changeProps = useSpring({ x: Number(change) || 0, from: { x: 0 } });
 
   return (
     <div className={styles.card}>
       <animated.div className={styles.value}>{props.x.interpolate(x => format(x))}</animated.div>
-      <div className={styles.label}>{label}</div>
+      <div className={styles.label}>
+        {label}
+        {~~change === 0 && <span className={styles.change}>{format(0)}</span>}
+        {~~change !== 0 && (
+          <animated.span
+            className={`${styles.change} ${
+              change >= 0
+                ? !reverseColors
+                  ? styles.positive
+                  : styles.negative
+                : !reverseColors
+                ? styles.negative
+                : styles.positive
+            }`}
+          >
+            {changeProps.x.interpolate(x => `${change >= 0 ? '+' : ''}${format(x)}`)}
+          </animated.span>
+        )}
+      </div>
     </div>
   );
 };

--- a/components/metrics/MetricCard.module.css
+++ b/components/metrics/MetricCard.module.css
@@ -16,4 +16,24 @@
 .label {
   font-size: var(--font-size-normal);
   white-space: nowrap;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.change {
+  font-size: 12px;
+  padding: 0 5px;
+  border-radius: 5px;
+  margin-left: 4px;
+  border: 1px solid var(--gray200);
+  color: var(--gray500);
+}
+
+.change.positive {
+  color: var(--green500);
+}
+
+.change.negative {
+  color: var(--red500);
 }

--- a/pages/api/website/[id]/stats.js
+++ b/pages/api/website/[id]/stats.js
@@ -14,10 +14,18 @@ export default async (req, res) => {
     const startDate = new Date(+start_at);
     const endDate = new Date(+end_at);
 
+    const distance = end_at - start_at;
+    const prevStartDate = new Date(+start_at - distance);
+    const prevEndDate = new Date(+end_at - distance);
+
     const metrics = await getWebsiteStats(websiteId, startDate, endDate, { url });
+    const prevPeriod = await getWebsiteStats(websiteId, prevStartDate, prevEndDate, { url });
 
     const stats = Object.keys(metrics[0]).reduce((obj, key) => {
-      obj[key] = Number(metrics[0][key]) || 0;
+      obj[key] = {
+        value: Number(metrics[0][key]) || 0,
+        change: Number(metrics[0][key] - prevPeriod[0][key]) || 0,
+      };
       return obj;
     }, {});
 


### PR DESCRIPTION
Hello! Decided to give another one a go since I also wanted this feature, this would resolve part of issue #600

- Adds comparison metrics to Metrics bar
- Gets comparison data from the previous period using the same time distance (if "This Week" then gets 7 days of data from 14 days ago for comparison to this week, which is the past 7 days.)
- Compares the two datasets and returns the difference between the two, green is for higher than previous period, red for lower than previous period.
- Uses existing formatting so number shortening works

Known Issues:
- My implementation uses the same number of days as the current selected period, meaning if the current month has 30 days, but the previous has 31 days, only 30 of the 31 days will be used for comparison.
- Stats API endpoint now uses two queries, for current and previous datasets

Hope this is useful, thanks!

![screenshot](https://user-images.githubusercontent.com/51844916/129278368-0d3bd5e3-81cd-4893-8fbc-fed936c55939.png)
