### PR TITLE
Fix checking prefers-color-scheme media query

### DIFF
--- a/hooks/useTheme.js
+++ b/hooks/useTheme.js
@@ -7,7 +7,7 @@ import { useEffect } from 'react';
 export default function useTheme() {
   const defaultTheme =
     typeof window !== 'undefined'
-      ? window?.matchMedia('prefers-color-scheme: dark')?.matches
+      ? window?.matchMedia('(prefers-color-scheme: dark)')?.matches
         ? 'dark'
         : 'light'
       : 'light';


### PR DESCRIPTION
The correct syntax to checking color scheme is `matchMedia('(prefers-color-scheme: dark)')`. Without parentheses, It will always return `false`.
https://web.dev/prefers-color-scheme/#finding-out-if-dark-mode-is-supported-by-the-browser