### PR TITLE
Autologin via token

### DIFF
--- a/components/forms/AutoLogin.js
+++ b/components/forms/AutoLogin.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { useRouter } from 'next/router';
+import usePost from 'hooks/usePost';
+
+export default function AutoLogin({ hash = null }) {
+  const post = usePost();
+  const router = useRouter();
+
+  const handleAutologin = async ({ hash }) => {
+    const autologin = await post('/api/auth/hash', {
+      hash,
+    });
+
+    if (autologin.ok) {
+      return router.push('/');
+    }
+  };
+
+  if (hash) {
+    handleAutologin({ hash });
+  }
+
+  return <div />;
+}

--- a/components/forms/LoginForm.js
+++ b/components/forms/LoginForm.js
@@ -27,24 +27,10 @@ const validate = ({ username, password }) => {
   return errors;
 };
 
-export default function LoginForm({ hash = null }) {
+export default function LoginForm() {
   const post = usePost();
   const router = useRouter();
   const [message, setMessage] = useState();
-
-  const handleAutologin = async ({ hash }) => {
-    const autologin = await post('/api/auth/hash', {
-      hash,
-    });
-
-    if (autologin.ok) {
-      return router.push('/');
-    }
-  };
-
-  if (hash) {
-    handleAutologin({ hash });
-  }
 
   const handleSubmit = async ({ username, password }) => {
     const { ok, status, data } = await post('/api/auth/login', {

--- a/components/forms/LoginForm.js
+++ b/components/forms/LoginForm.js
@@ -27,10 +27,24 @@ const validate = ({ username, password }) => {
   return errors;
 };
 
-export default function LoginForm() {
+export default function LoginForm({ hash = null }) {
   const post = usePost();
   const router = useRouter();
   const [message, setMessage] = useState();
+
+  const handleAutologin = async ({ hash }) => {
+    const autologin = await post('/api/auth/hash', {
+      hash,
+    });
+
+    if (autologin.ok) {
+      return router.push('/');
+    }
+  };
+
+  if (hash) {
+    handleAutologin({ hash });
+  }
 
   const handleSubmit = async ({ username, password }) => {
     const { ok, status, data } = await post('/api/auth/login', {

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -6,7 +6,7 @@ export const TIMEZONE_CONFIG = `${prefix}.timezone`;
 export const DATE_RANGE_CONFIG = `${prefix}.date-range`;
 export const THEME_CONFIG = `${prefix}.theme`;
 export const VERSION_CHECK = `${prefix}.version-check`;
-export const TOKEN_HEADER = 'x-${prefix}-token';
+export const TOKEN_HEADER = `x-${prefix}-token`;
 
 export const DEFAULT_LOCALE = 'en-US';
 export const DEFAULT_THEME = 'light';

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,10 +1,12 @@
-export const AUTH_COOKIE_NAME = 'umami.auth';
-export const LOCALE_CONFIG = 'umami.locale';
-export const TIMEZONE_CONFIG = 'umami.timezone';
-export const DATE_RANGE_CONFIG = 'umami.date-range';
-export const THEME_CONFIG = 'umami.theme';
-export const VERSION_CHECK = 'umami.version-check';
-export const TOKEN_HEADER = 'x-umami-token';
+const prefix = process.env.UMAMI_CONST_PREFIX || 'umami';
+
+export const AUTH_COOKIE_NAME = `${prefix}.auth`;
+export const LOCALE_CONFIG = `${prefix}.locale`;
+export const TIMEZONE_CONFIG = `${prefix}.timezone`;
+export const DATE_RANGE_CONFIG = `${prefix}.date-range`;
+export const THEME_CONFIG = `${prefix}.theme`;
+export const VERSION_CHECK = `${prefix}.version-check`;
+export const TOKEN_HEADER = 'x-${prefix}-token';
 
 export const DEFAULT_LOCALE = 'en-US';
 export const DEFAULT_THEME = 'light';
@@ -80,7 +82,8 @@ export const POSTGRESQL_DATE_FORMATS = {
   year: 'YYYY-01-01',
 };
 
-export const DOMAIN_REGEX = /^(localhost(:[1-9]\d{0,4})?|((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,63})$/;
+export const DOMAIN_REGEX =
+  /^(localhost(:[1-9]\d{0,4})?|((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,63})$/;
 
 export const DESKTOP_SCREEN_WIDTH = 1920;
 export const LAPTOP_SCREEN_WIDTH = 1024;

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -8,6 +8,9 @@ export const THEME_CONFIG = `${prefix}.theme`;
 export const VERSION_CHECK = `${prefix}.version-check`;
 export const TOKEN_HEADER = `x-${prefix}-token`;
 
+export const SHOW_HEADER = false;
+export const SHOW_FOOTER = false;
+
 export const DEFAULT_LOCALE = 'en-US';
 export const DEFAULT_THEME = 'light';
 export const DEFAUL_CHART_HEIGHT = 400;

--- a/lib/queries.js
+++ b/lib/queries.js
@@ -223,6 +223,16 @@ export async function getAccountById(user_id) {
   );
 }
 
+export async function getAccountByHash(hash) {
+  return runQuery(
+    prisma.account.findUnique({
+      where: {
+        hash,
+      },
+    }),
+  );
+}
+
 export async function getAccountByUsername(username) {
   return runQuery(
     prisma.account.findUnique({

--- a/pages/api/auth/hash.js
+++ b/pages/api/auth/hash.js
@@ -1,0 +1,32 @@
+import { serialize } from 'cookie';
+import { createSecureToken } from 'lib/crypto';
+import { getAccountByHash } from 'lib/queries';
+import { AUTH_COOKIE_NAME } from 'lib/constants';
+import { ok, unauthorized, badRequest } from 'lib/response';
+
+export default async (req, res) => {
+  const { hash } = req.body;
+
+  if (!hash) {
+    return badRequest(res);
+  }
+
+  const account = await getAccountByHash(hash);
+
+  if (account) {
+    const { user_id, username, is_admin } = account;
+    const token = await createSecureToken({ user_id, username, is_admin });
+    const cookie = serialize(AUTH_COOKIE_NAME, token, {
+      path: '/',
+      httpOnly: true,
+      sameSite: true,
+      maxAge: 60 * 60 * 24 * 365,
+    });
+
+    res.setHeader('Set-Cookie', [cookie]);
+
+    return ok(res, { token });
+  }
+
+  return unauthorized(res);
+};

--- a/pages/dashboard/[[...id]].js
+++ b/pages/dashboard/[[...id]].js
@@ -15,7 +15,7 @@ export default function DashboardPage() {
   }
 
   return (
-    <Layout>
+    <Layout header={false} footer={false}>
       <WebsiteList userId={userId} />
     </Layout>
   );

--- a/pages/dashboard/[[...id]].js
+++ b/pages/dashboard/[[...id]].js
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import Layout from 'components/layout/Layout';
 import WebsiteList from 'components/pages/WebsiteList';
 import useRequireLogin from 'hooks/useRequireLogin';
+import { SHOW_HEADER, SHOW_FOOTER } from 'lib/constants';
 
 export default function DashboardPage() {
   const { loading } = useRequireLogin();
@@ -15,7 +16,7 @@ export default function DashboardPage() {
   }
 
   return (
-    <Layout header={false} footer={false}>
+    <Layout header={SHOW_HEADER} footer={SHOW_FOOTER}>
       <WebsiteList userId={userId} />
     </Layout>
   );

--- a/pages/login.js
+++ b/pages/login.js
@@ -1,13 +1,17 @@
 import React from 'react';
 import Layout from 'components/layout/Layout';
 import LoginForm from 'components/forms/LoginForm';
+import AutoLogin from 'components/forms/AutoLogin';
 import { useRouter } from 'next/router';
 
 export default function LoginPage() {
   const { query } = useRouter();
+  if (query.hash) {
+    return <AutoLogin hash={query.hash} />;
+  }
   return (
     <Layout title="login" header={false} footer={false} center>
-      <LoginForm hash={query.hash} />
+      <LoginForm />
     </Layout>
   );
 }

--- a/pages/login.js
+++ b/pages/login.js
@@ -7,11 +7,16 @@ import { useRouter } from 'next/router';
 export default function LoginPage() {
   const { query } = useRouter();
   if (query.hash) {
-    return <AutoLogin hash={query.hash} />;
+    return (
+      <Layout title="login" header={false} footer={false} center>
+        <AutoLogin hash={query.hash} />
+      </Layout>
+    );
+  } else {
+    return (
+      <Layout title="login" header={false} footer={false} center>
+        <LoginForm />
+      </Layout>
+    );
   }
-  return (
-    <Layout title="login" header={false} footer={false} center>
-      <LoginForm />
-    </Layout>
-  );
 }

--- a/pages/login.js
+++ b/pages/login.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import Layout from 'components/layout/Layout';
 import LoginForm from 'components/forms/LoginForm';
+import { useRouter } from 'next/router';
 
 export default function LoginPage() {
+  const { query } = useRouter();
   return (
     <Layout title="login" header={false} footer={false} center>
-      <LoginForm />
+      <LoginForm hash={query.hash} />
     </Layout>
   );
 }

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Layout from 'components/layout/Layout';
 import Settings from 'components/pages/Settings';
 import useRequireLogin from 'hooks/useRequireLogin';
+import { SHOW_HEADER, SHOW_FOOTER } from 'lib/constants';
 
 export default function SettingsPage() {
   const { loading } = useRequireLogin();
@@ -11,7 +12,7 @@ export default function SettingsPage() {
   }
 
   return (
-    <Layout>
+    <Layout header={SHOW_HEADER} footer={SHOW_FOOTER}>
       <Settings />
     </Layout>
   );

--- a/pages/website/[...id].js
+++ b/pages/website/[...id].js
@@ -16,7 +16,7 @@ export default function DetailsPage() {
   const [websiteId] = id;
 
   return (
-    <Layout>
+    <Layout header={false} footer={false}>
       <WebsiteDetails websiteId={websiteId} />
     </Layout>
   );

--- a/pages/website/[...id].js
+++ b/pages/website/[...id].js
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import Layout from 'components/layout/Layout';
 import WebsiteDetails from 'components/pages/WebsiteDetails';
 import useRequireLogin from 'hooks/useRequireLogin';
+import { SHOW_HEADER, SHOW_FOOTER } from 'lib/constants';
 
 export default function DetailsPage() {
   const { loading } = useRequireLogin();
@@ -16,7 +17,7 @@ export default function DetailsPage() {
   const [websiteId] = id;
 
   return (
-    <Layout header={false} footer={false}>
+    <Layout header={SHOW_HEADER} footer={SHOW_FOOTER}>
       <WebsiteDetails websiteId={websiteId} />
     </Layout>
   );

--- a/prisma/schema.mysql.prisma
+++ b/prisma/schema.mysql.prisma
@@ -11,6 +11,7 @@ model account {
   user_id    Int       @id @default(autoincrement()) @db.UnsignedInt
   username   String    @unique @db.VarChar(255)
   password   String    @db.VarChar(60)
+  hash       String    @unique @db.VarChar(512)
   is_admin   Boolean   @default(false)
   created_at DateTime? @default(now()) @db.Timestamp(0)
   updated_at DateTime? @default(now()) @db.Timestamp(0)

--- a/prisma/schema.postgresql.prisma
+++ b/prisma/schema.postgresql.prisma
@@ -11,6 +11,7 @@ model account {
   user_id    Int       @id @default(autoincrement())
   username   String    @unique @db.VarChar(255)
   password   String    @db.VarChar(60)
+  hash       String    @unique @db.VarChar(512)
   is_admin   Boolean   @default(false)
   created_at DateTime? @default(now()) @db.Timestamptz(6)
   updated_at DateTime? @default(now()) @db.Timestamptz(6)


### PR DESCRIPTION
By adding a `hash` column to the `account` table and enabling a new api endpoint, `/api/auth/hash`, I made it possible to autologin any user by accessing `/login?hash=xxx`.
I'm using Umami as part of a bigger framework, where it becomes a page of an admin dashboard, where I already know if a user is logged in and I wanted to avoid generating chaos having multiple accounts on multiple services.
In this way i can create a token, share it between Umami and the container system in order to bypass a redundant step

This is how it looks like
![image](https://user-images.githubusercontent.com/3661363/137071249-e1531586-1c4c-4b4a-9550-84d5e7e0e777.png)

PS: i also added a parametrical hiding of header/footer using constants, but it would be ideal to have them valued by some external config