### PR TITLE
Add TiDB doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm install
 
 ### Create database tables
 
-Umami supports [MySQL](https://www.mysql.com/) and [Postgresql](https://www.postgresql.org/).
+Umami supports [MySQL](https://www.mysql.com/), [TiDB](https://github.com/pingcap/tidb) and [Postgresql](https://www.postgresql.org/).
 Create a database for your Umami installation and install the tables with the included scripts.
 
 For MySQL:


### PR DESCRIPTION
[TiDB](https://github.com/pingcap/tidb) is a MySQL-compatible database that supports Hybrid Transactional and Analytical Processing (HTAP) workloads. It can be used as a replacement for MySQL (same protocol and syntax). We have already seen some TiDB users using TiDB with umami together. So it would be great that we can have TiDB in the supported databases list.

The following is my practice, I hope to help more people integrate TiDB and umami

## Prerequisites

* Docker
* Docker Compose
* An existing TiDB database


## Get the docker-compose file

```
git clone https://github.com/mikecao/umami.git
```

## docker-compose setting for TiDB

cd umami & edit docker-compose file:

```yaml
version: '3'
services:
  umami:
    image: ghcr.io/mikecao/umami:mysql-latest
    ports:
      - "3000:3000"
    environment:
      DATABASE_URL: mysql://root:@db:4000/umami
      DATABASE_TYPE: mysql
      HASH_SALT: replace-me-with-a-random-string
    depends_on:
      - db
    restart: always
  db:
    image: hooopo/tidb-playground:v5.2.0
    environment:
      TIDB_VERSION: v5.2.0
    restart: always
    ports:
      - "4000:4000"
volumes:
  umami-db-data:
```

## Create database 

```bash
mysql --host 127.0.0.1 --port 4000 -u root -p -e 'create database umami'
```

## Import database schema

```bash
mysql --comments --host 127.0.0.1 --port 4000 -u root -p umami < sql/schema.mysql.sql
```

## Run umami

```bash
docker-compose up
```

## Try out the umami dashboard

open http://localhost:3000

user: admin
password: umami

![image](https://user-images.githubusercontent.com/63877/131800973-ec2e3d2a-d09f-4528-adcf-8320af0f7503.png)


## TiDB production deployment setup

* see https://docs.pingcap.com/tidb/stable/production-deployment-using-tiup