### PR TITLE
QoL changes on tracker

### DIFF
--- a/lib/web.js
+++ b/lib/web.js
@@ -44,17 +44,14 @@ export const hook = (_this, method, callback) => {
 export const doNotTrack = () => {
   const { doNotTrack, navigator, external } = window;
 
+  const msTrackProtection = 'msTrackingProtectionEnabled';
   const msTracking = () => {
-    return (
-      external &&
-      typeof external.msTrackingProtectionEnabled === 'function' &&
-      external.msTrackingProtectionEnabled()
-    );
+    return external && msTrackProtection in external && external[msTrackProtection]();
   };
 
   const dnt = doNotTrack || navigator.doNotTrack || navigator.msDoNotTrack || msTracking();
 
-  return dnt === true || dnt === 1 || dnt === 'yes' || dnt === '1';
+  return dnt == '1' || dnt === 'yes';
 };
 
 export const setItem = (key, data, session) => {


### PR DESCRIPTION
- Remove redundant checks and returns
- Add an additional check for local storage (some browsers still lack it)
- Using some better practices
- Use MutationObserver for events
- Add initial events on DOM full render, send first trackView on complete readyState

The only detail is that with this, `addEvents` and `removeEvents` were removed from `window.umami`, and it's only supposed to be tracked automatically from mutations, so I'm unsure of how much would this impact.