### PR TITLE
Add light/dark switch to meta theme-color

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -39,7 +39,8 @@ export default function App({ Component, pageProps }) {
         <link rel="manifest" href={`${basePath}/site.webmanifest`} />
         <link rel="mask-icon" href={`${basePath}/safari-pinned-tab.svg`} color="#5bbad5" />
         <meta name="msapplication-TileColor" content="#da532c" />
-        <meta name="theme-color" content="#ffffff" />
+         <meta name="theme-color" content="##fafafa" media="(prefers-color-scheme: light)" />
+        <meta name="theme-color" content="##2f2f2f" media="(prefers-color-scheme: dark)" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </Head>
       <Intl>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -39,8 +39,8 @@ export default function App({ Component, pageProps }) {
         <link rel="manifest" href={`${basePath}/site.webmanifest`} />
         <link rel="mask-icon" href={`${basePath}/safari-pinned-tab.svg`} color="#5bbad5" />
         <meta name="msapplication-TileColor" content="#da532c" />
-         <meta name="theme-color" content="##fafafa" media="(prefers-color-scheme: light)" />
-        <meta name="theme-color" content="##2f2f2f" media="(prefers-color-scheme: dark)" />
+         <meta name="theme-color" content="#fafafa" media="(prefers-color-scheme: light)" />
+        <meta name="theme-color" content="#2f2f2f" media="(prefers-color-scheme: dark)" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </Head>
       <Intl>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -39,8 +39,8 @@ export default function App({ Component, pageProps }) {
         <link rel="manifest" href={`${basePath}/site.webmanifest`} />
         <link rel="mask-icon" href={`${basePath}/safari-pinned-tab.svg`} color="#5bbad5" />
         <meta name="msapplication-TileColor" content="#da532c" />
-         <meta name="theme-color" content="#fafafa" media="(prefers-color-scheme: light)" />
-        <meta name="theme-color" content="#2f2f2f" media="(prefers-color-scheme: dark)" />
+         <meta name="theme-color" content="##fafafa" media="(prefers-color-scheme: light)" />
+        <meta name="theme-color" content="##2f2f2f" media="(prefers-color-scheme: dark)" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </Head>
       <Intl>


### PR DESCRIPTION
The color of the header meta theme color was set to default white (#ffffff), this will change it to respond to dark/light mode toggle. 
https://css-tricks.com/meta-theme-color-and-trickery/
![image](https://user-images.githubusercontent.com/46720448/142209518-0a24947a-71ff-4619-a9d3-58f8033de52e.png)
![image](https://user-images.githubusercontent.com/46720448/142209556-86684d8b-33bc-4737-82f9-d91c8852665c.png)
