### PR TITLE
Add all time date filter

### DIFF
--- a/components/common/DateFilter.js
+++ b/components/common/DateFilter.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
 import { FormattedMessage } from 'react-intl';
 import { endOfYear, isSameDay } from 'date-fns';
 import Modal from './Modal';
@@ -48,15 +49,21 @@ const filterOptions = [
   },
   { label: <FormattedMessage id="label.this-year" defaultMessage="This year" />, value: '1year' },
   {
+    label: <FormattedMessage id="label.all-time" defaultMessage="All Time" />,
+    value: 'all',
+    divider: true,
+  },
+  {
     label: <FormattedMessage id="label.custom-range" defaultMessage="Custom range" />,
     value: 'custom',
     divider: true,
   },
 ];
 
-function DateFilter({ value, startDate, endDate, onChange, className }) {
+function DateFilter({ value, startDate, endDate, onChange, className, websiteId = null }) {
   const { locale } = useLocale();
   const [showPicker, setShowPicker] = useState(false);
+  const createdAt = useSelector(state => state.websites[websiteId]?.createdAt);
   const displayValue =
     value === 'custom' ? (
       <CustomRange startDate={startDate} endDate={endDate} onClick={() => handleChange('custom')} />
@@ -69,7 +76,7 @@ function DateFilter({ value, startDate, endDate, onChange, className }) {
       setShowPicker(true);
       return;
     }
-    onChange(getDateRange(value, locale));
+    onChange(getDateRange(value, locale, createdAt));
   }
 
   function handlePickerChange(value) {

--- a/components/common/DateFilter.js
+++ b/components/common/DateFilter.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import { FormattedMessage } from 'react-intl';
@@ -60,7 +60,15 @@ const filterOptions = [
   },
 ];
 
-function DateFilter({ value, startDate, endDate, onChange, className, websiteId = null }) {
+function DateFilter({
+  value,
+  startDate,
+  endDate,
+  onChange,
+  className,
+  websiteId = null,
+  disableOptions = [],
+}) {
   const { locale } = useLocale();
   const [showPicker, setShowPicker] = useState(false);
   const createdAt = useSelector(state => state.websites[websiteId]?.createdAt);
@@ -70,6 +78,15 @@ function DateFilter({ value, startDate, endDate, onChange, className, websiteId 
     ) : (
       value
     );
+
+  const filteredOptions = useMemo(() => {
+    const clone = [...filterOptions];
+    for (const option of disableOptions) {
+      const index = clone.findIndex(a => a.value == option);
+      if (index >= 0) clone.splice(index, 1);
+    }
+    return clone;
+  }, [disableOptions]);
 
   function handleChange(value) {
     if (value === 'custom') {
@@ -89,7 +106,7 @@ function DateFilter({ value, startDate, endDate, onChange, className, websiteId 
       <DropDown
         className={className}
         value={displayValue}
-        options={filterOptions}
+        options={filteredOptions}
         onChange={handleChange}
       />
       {showPicker && (

--- a/components/common/RefreshButton.js
+++ b/components/common/RefreshButton.js
@@ -16,11 +16,12 @@ function RefreshButton({ websiteId }) {
   const [dateRange] = useDateRange(websiteId);
   const [loading, setLoading] = useState(false);
   const completed = useSelector(state => state.queries[`/api/website/${websiteId}/stats`]);
+  const createdAt = useSelector(state => state.websites[websiteId]?.createdAt);
 
   function handleClick() {
     if (dateRange) {
       setLoading(true);
-      dispatch(setDateRange(websiteId, getDateRange(dateRange.value, locale)));
+      dispatch(setDateRange(websiteId, getDateRange(dateRange.value, locale, createdAt)));
     }
   }
 

--- a/components/metrics/MetricsBar.js
+++ b/components/metrics/MetricsBar.js
@@ -15,7 +15,7 @@ import styles from './MetricsBar.module.css';
 export default function MetricsBar({ websiteId, className }) {
   const shareToken = useShareToken();
   const [dateRange] = useDateRange(websiteId);
-  const { startDate, endDate, modified } = dateRange;
+  const { startDate, endDate, modified, value } = dateRange;
   const [format, setFormat] = useState(true);
   const {
     query: { url, ref },
@@ -63,12 +63,14 @@ export default function MetricsBar({ websiteId, className }) {
             value={pageviews.value}
             change={pageviews.change}
             format={formatFunc}
+            hideComparison={value === 'all'}
           />
           <MetricCard
             label={<FormattedMessage id="metrics.visitors" defaultMessage="Visitors" />}
             value={uniques.value}
             change={uniques.change}
             format={formatFunc}
+            hideComparison={value === 'all'}
           />
           <MetricCard
             label={<FormattedMessage id="metrics.bounce-rate" defaultMessage="Bounce rate" />}
@@ -80,6 +82,7 @@ export default function MetricsBar({ websiteId, className }) {
                 : 0
             }
             format={n => Number(n).toFixed(0) + '%'}
+            hideComparison={value === 'all'}
             reverseColors
           />
           <MetricCard
@@ -102,6 +105,7 @@ export default function MetricsBar({ websiteId, className }) {
                 : 0
             }
             format={n => `${n < 0 ? '-' : ''}${formatShortTime(Math.abs(~~n), ['m', 's'], ' ')}`}
+            hideComparison={value === 'all'}
           />
         </>
       )}

--- a/components/metrics/WebsiteChart.js
+++ b/components/metrics/WebsiteChart.js
@@ -85,6 +85,7 @@ export default function WebsiteChart({
               startDate={startDate}
               endDate={endDate}
               onChange={setDateRange}
+              websiteId={websiteId}
             />
           </div>
         </StickyHeader>

--- a/components/pages/WebsiteDetails.js
+++ b/components/pages/WebsiteDetails.js
@@ -1,4 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { setWebsiteCreated } from 'redux/actions/websites';
 import { FormattedMessage } from 'react-intl';
 import classNames from 'classnames';
 import WebsiteChart from 'components/metrics/WebsiteChart';
@@ -34,6 +36,7 @@ const views = {
 };
 
 export default function WebsiteDetails({ websiteId }) {
+  const dispatch = useDispatch();
   const shareToken = useShareToken();
   const { data } = useFetch(`/api/website/${websiteId}`, {
     headers: { [TOKEN_HEADER]: shareToken?.token },
@@ -45,6 +48,10 @@ export default function WebsiteDetails({ websiteId }) {
     resolve,
     query: { view },
   } = usePageQuery();
+
+  useEffect(() => {
+    if (data) dispatch(setWebsiteCreated(websiteId, data.created_at));
+  }, [data]);
 
   const BackButton = () => (
     <div key="back-button" className={styles.backButton}>

--- a/components/pages/WebsiteList.js
+++ b/components/pages/WebsiteList.js
@@ -1,4 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { setWebsiteCreated } from 'redux/actions/websites';
 import { FormattedMessage } from 'react-intl';
 import Link from 'components/common/Link';
 import WebsiteChart from 'components/metrics/WebsiteChart';
@@ -11,8 +13,13 @@ import Chart from 'assets/chart-bar.svg';
 import styles from './WebsiteList.module.css';
 
 export default function WebsiteList({ userId }) {
+  const dispatch = useDispatch();
   const { data } = useFetch('/api/websites', { params: { user_id: userId } });
   const [hideCharts, setHideCharts] = useState(false);
+
+  useEffect(() => {
+    if (data) data.map(i => dispatch(setWebsiteCreated(i.website_id, i.created_at)));
+  }, [data]);
 
   if (!data) {
     return null;

--- a/components/settings/DateRangeSetting.js
+++ b/components/settings/DateRangeSetting.js
@@ -19,7 +19,13 @@ export default function DateRangeSetting() {
 
   return (
     <>
-      <DateFilter value={value} startDate={startDate} endDate={endDate} onChange={setDateRange} />
+      <DateFilter
+        value={value}
+        startDate={startDate}
+        endDate={endDate}
+        onChange={setDateRange}
+        disableOptions={['all']}
+      />
       <Button className={styles.button} size="small" onClick={handleReset}>
         <FormattedMessage id="label.reset" defaultMessage="Reset" />
       </Button>

--- a/lang/en-US.json
+++ b/lang/en-US.json
@@ -4,6 +4,7 @@
   "label.add-website": "Add website",
   "label.administrator": "Administrator",
   "label.all": "All",
+  "label.all-time": "All Time",
   "label.all-events": "All events",
   "label.all-websites": "All websites",
   "label.back": "Back",

--- a/lib/date.js
+++ b/lib/date.js
@@ -41,31 +41,37 @@ export function getDateRange(value, locale = 'en-US', createdAt = null) {
 
   if (value === 'all') {
     createdAt = new Date(createdAt);
+
     const diff = Math.abs(differenceInCalendarDays(createdAt, now));
+    const breakpoints = {
+      day: 1,
+      month: 90,
+      year: 1095,
+    };
 
     if (createdAt) {
-      if (diff <= 1) {
+      if (diff <= breakpoints.day) {
         return {
           startDate: startOfDay(createdAt),
           endDate: endOfDay(now),
           unit: 'hour',
           value,
         };
-      } else if (diff <= 90 && diff > 1) {
+      } else if (diff <= breakpoints.month && diff > breakpoints.day) {
         return {
           startDate: startOfWeek(createdAt),
           endDate: endOfWeek(now),
           unit: 'day',
           value,
         };
-      } else if (diff <= 1095 && diff > 90) {
+      } else if (diff <= breakpoints.year && diff > breakpoints.month) {
         return {
           startDate: startOfMonth(createdAt),
           endDate: endOfMonth(now),
           unit: 'month',
           value,
         };
-      } else if (diff > 1095) {
+      } else if (diff > breakpoints.year) {
         return {
           startDate: startOfYear(createdAt),
           endDate: endOfYear(now),
@@ -74,8 +80,9 @@ export function getDateRange(value, locale = 'en-US', createdAt = null) {
         };
       }
     }
+
     return {
-      startDate: startOfYear(createdAt),
+      startDate: startOfYear(now),
       endDate: endOfYear(now),
       unit: 'year',
       value,

--- a/lib/date.js
+++ b/lib/date.js
@@ -35,9 +35,52 @@ export function getLocalTime(t) {
   return addMinutes(new Date(t), new Date().getTimezoneOffset());
 }
 
-export function getDateRange(value, locale = 'en-US') {
+export function getDateRange(value, locale = 'en-US', createdAt = null) {
   const now = new Date();
   const dateLocale = getDateLocale(locale);
+
+  if (value === 'all') {
+    createdAt = new Date(createdAt);
+    const diff = Math.abs(differenceInCalendarDays(createdAt, now));
+
+    if (createdAt) {
+      if (diff <= 1) {
+        return {
+          startDate: startOfDay(createdAt),
+          endDate: endOfDay(now),
+          unit: 'hour',
+          value,
+        };
+      } else if (diff <= 90 && diff > 1) {
+        return {
+          startDate: startOfWeek(createdAt),
+          endDate: endOfWeek(now),
+          unit: 'day',
+          value,
+        };
+      } else if (diff <= 1095 && diff > 90) {
+        return {
+          startDate: startOfMonth(createdAt),
+          endDate: endOfMonth(now),
+          unit: 'month',
+          value,
+        };
+      } else if (diff > 1095) {
+        return {
+          startDate: startOfYear(createdAt),
+          endDate: endOfYear(now),
+          unit: 'year',
+          value,
+        };
+      }
+    }
+    return {
+      startDate: startOfYear(createdAt),
+      endDate: endOfYear(now),
+      unit: 'year',
+      value,
+    };
+  }
 
   const { num, unit } = value.match(/^(?<num>[0-9]+)(?<unit>hour|day|week|month|year)$/).groups;
 

--- a/redux/actions/websites.js
+++ b/redux/actions/websites.js
@@ -10,7 +10,7 @@ const websites = createSlice({
     },
     updateWebsite(state, action) {
       const { websiteId, ...data } = action.payload;
-      state[websiteId] = data;
+      state[websiteId] = { ...state[websiteId], ...data };
       return state;
     },
   },
@@ -25,5 +25,11 @@ export function setDateRange(websiteId, dateRange) {
     return dispatch(
       updateWebsite({ websiteId, dateRange: { ...dateRange, modified: Date.now() } }),
     );
+  };
+}
+
+export function setWebsiteCreated(websiteId, createdAt) {
+  return dispatch => {
+    return dispatch(updateWebsite({ websiteId, createdAt }));
   };
 }


### PR DESCRIPTION
Hello, this builds on top of #818 and solves #554. The date range and units are automatically calculated using breakpoints and the website created date. I stored the created at value on initial load within redux instead of fetching API data a second time when all-data is clicked.

The only issue is that i've disable the all-time filter as a default date range. Initial page load with the all time filter as default caused the chart to show data from 1970/epoch to now, since there is no way to get the created date before fetching the data.

I was not able to figure out how to force a chart refresh after the data has been fetched, the logic within the refresh button seems to work but I could not adapt it to force an update after fetching the data. Do you have any recommendations on how to fix/implement that? As for now, the option to have all-time as default is disabled in this PR until we can force a chart refresh after data has been loaded into redux.

Thanks.