### PR TITLE
add netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[functions]
+included_files = ["public/geo/*.mmdb"]


### PR DESCRIPTION
for part of #731

Netlify next functions plugin is no longer copying in the build files. This adds the db file from the build into the functions.