### PR TITLE
Don't show metric change indicator when metric delta is 0 (resolves #772)

### DIFF
--- a/components/metrics/MetricCard.js
+++ b/components/metrics/MetricCard.js
@@ -19,7 +19,6 @@ const MetricCard = ({
       <animated.div className={styles.value}>{props.x.interpolate(x => format(x))}</animated.div>
       <div className={styles.label}>
         {label}
-        {~~change === 0 && !hideComparison && <span className={styles.change}>{format(0)}</span>}
         {~~change !== 0 && !hideComparison && (
           <animated.span
             className={`${styles.change} ${


### PR DESCRIPTION
As discussed in #772, showing "0" next to an unchanged metric can be a bit confusing at first glance. There were two suggeestions: one to show an equals sign instead, and one to just show nothing in the case of the metric being unchanged.

They both seem like equivalent suggestions, but I went with just showing nothing.