### PR TITLE
Truncate text & show tooltip when website name is too long (Resolves #925)

### DIFF
--- a/components/common/OverflowText.js
+++ b/components/common/OverflowText.js
@@ -1,0 +1,66 @@
+import PropTypes from 'prop-types';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import ReactTooltip from 'react-tooltip';
+
+import styles from './OverflowText.module.css';
+
+const OverflowText = ({ children, tooltipId }) => {
+  const measureEl = useRef();
+  const [isOverflown, setIsOverflown] = useState(false);
+
+  const measure = useCallback(
+    el => {
+      if (!el) return;
+      setIsOverflown(el.scrollWidth > el.clientWidth);
+    },
+    [setIsOverflown],
+  );
+
+  // Do one measure on mount
+  useEffect(() => {
+    measure(measureEl.current);
+  }, [measure]);
+
+  // Set up resize listener for subsequent measures
+  useEffect(() => {
+    if (!measureEl.current) return;
+
+    // Destructure ref in case it changes out from under us
+    const el = measureEl.current;
+
+    if ('ResizeObserver' in global) {
+      // Ideally, we have access to ResizeObservers
+      const observer = new ResizeObserver(() => {
+        measure(el);
+      });
+      observer.observe(el);
+      return () => observer.unobserve(el);
+    } else {
+      // Otherwise, fall back to measuring on window resizes
+      const handler = () => measure(el);
+
+      window.addEventListener('resize', handler, { passive: true });
+      return () => window.removeEventListener('resize', handler, { passive: true });
+    }
+  });
+
+  return (
+    <span
+      ref={measureEl}
+      data-tip={children.toString()}
+      data-effect="solid"
+      data-for={tooltipId}
+      className={styles.root}
+    >
+      {children}
+      {isOverflown && <ReactTooltip id={tooltipId}>{children}</ReactTooltip>}
+    </span>
+  );
+};
+
+OverflowText.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+  tooltipId: PropTypes.string.isRequired,
+};
+
+export default OverflowText;

--- a/components/common/OverflowText.module.css
+++ b/components/common/OverflowText.module.css
@@ -1,0 +1,6 @@
+.root {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/components/metrics/WebsiteHeader.js
+++ b/components/metrics/WebsiteHeader.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import Link from 'components/common/Link';
+import OverflowText from 'components/common/OverflowText';
 import PageHeader from 'components/layout/PageHeader';
 import RefreshButton from 'components/common/RefreshButton';
 import ButtonLayout from 'components/layout/ButtonLayout';
@@ -13,15 +14,19 @@ export default function WebsiteHeader({ websiteId, title, domain, showLink = fal
   const header = showLink ? (
     <>
       <Favicon domain={domain} />
-      <Link href="/website/[...id]" as={`/website/${websiteId}/${title}`}>
-        {title}
+      <Link
+        className={styles.titleLink}
+        href="/website/[...id]"
+        as={`/website/${websiteId}/${title}`}
+      >
+        <OverflowText tooltipId={`${websiteId}-title`}>{title}</OverflowText>
       </Link>
     </>
   ) : (
-    <div>
+    <>
       <Favicon domain={domain} />
-      {title}
-    </div>
+      <OverflowText tooltipId={`${websiteId}-title`}>{title}</OverflowText>
+    </>
   );
 
   return (

--- a/components/metrics/WebsiteHeader.module.css
+++ b/components/metrics/WebsiteHeader.module.css
@@ -2,6 +2,14 @@
   color: var(--gray900);
   font-size: var(--font-size-large);
   line-height: var(--font-size-large);
+  align-items: center;
+  display: flex;
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.titleLink {
+  max-width: 100%;
 }
 
 .link {

--- a/components/settings/WebsiteSettings.js
+++ b/components/settings/WebsiteSettings.js
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 import Link from 'components/common/Link';
 import Table from 'components/common/Table';
 import Button from 'components/common/Button';
+import OverflowText from 'components/common/OverflowText';
 import PageHeader from 'components/layout/PageHeader';
 import Modal from 'components/common/Modal';
 import WebsiteEditForm from 'components/forms/WebsiteEditForm';
@@ -84,10 +85,18 @@ export default function WebsiteSettings() {
   );
 
   const DetailsLink = ({ website_id, name, domain }) => (
-    <Link href="/website/[...id]" as={`/website/${website_id}/${name}`}>
+    <Link
+      className={styles.detailLink}
+      href="/website/[...id]"
+      as={`/website/${website_id}/${name}`}
+    >
       <Favicon domain={domain} />
-      {name}
+      <OverflowText tooltipId={`${website_id}-name`}>{name}</OverflowText>
     </Link>
+  );
+
+  const Domain = ({ domain, website_id }) => (
+    <OverflowText tooltipId={`${website_id}-domain`}>{domain}</OverflowText>
   );
 
   const adminColumns = [
@@ -101,6 +110,7 @@ export default function WebsiteSettings() {
       key: 'domain',
       label: <FormattedMessage id="label.domain" defaultMessage="Domain" />,
       className: 'col-4 col-xl-3',
+      render: Domain,
     },
     {
       key: 'account',
@@ -125,6 +135,7 @@ export default function WebsiteSettings() {
       key: 'domain',
       label: <FormattedMessage id="label.domain" defaultMessage="Domain" />,
       className: 'col-6 col-xl-4',
+      render: Domain,
     },
     {
       key: 'action',

--- a/components/settings/WebsiteSettings.module.css
+++ b/components/settings/WebsiteSettings.module.css
@@ -5,3 +5,7 @@
 .buttons {
   justify-content: flex-end;
 }
+
+.detailLink {
+  width: 100%;
+}


### PR DESCRIPTION
In the websites table, website names & domains can overlap when they long enough to overflow the boundaries of their table cell. This PR adds some code which truncates the text with an ellipses, and shows a tooltip when the user hovers over the data (*if* it overflowed) like so:

<img width="423" alt="Screen Shot 2022-02-20 at 2 06 26 PM" src="https://user-images.githubusercontent.com/20146550/154824991-51711c22-1ad5-4fb9-bb06-69e0a39a3d73.png">

A `ResizeObserver` is used to track when the element changes size (e.g. from the browser window being resized) but there's a fallback to the window's resize event in case `ResizeObserver` isn't available.

I've also added the same functionality to `WebsiteHeader`, and verified this all works on at least iOS:

![IMG_1087](https://user-images.githubusercontent.com/20146550/154825032-d2b097ea-22b7-4334-bd5a-63da7e2ef2b5.PNG)

<img width="1220" alt="Screen Shot 2022-02-20 at 2 39 56 PM" src="https://user-images.githubusercontent.com/20146550/154825045-c7fabbb0-0820-4ebb-be8d-16c9f1767094.png">

(Note that while working on this I noticed that a website with a name of 100x 'w' characters will break the `WebsiteList` page, and cause the table to get pushed down below the sidebar for seemingly no reason. This is already the case in the stock master branch, and I decided fixing it is out of scope for this PR.)

