### PR TITLE
support multiple track script name

### DIFF
--- a/pages/_middleware.js
+++ b/pages/_middleware.js
@@ -15,10 +15,15 @@ function customScriptName(req) {
   const scriptName = process.env.TRACKER_SCRIPT_NAME;
 
   if (scriptName) {
+    const names = scriptName.split(',').map(name => name + '.js');
+
     const url = req.nextUrl.clone();
     const { pathname } = url;
 
-    if (pathname.endsWith(`/${scriptName}.js`)) {
+    const pathNameParts = pathname.split('/');
+    const lastPathName = pathNameParts[pathNameParts.length - 1];
+
+    if (names.indexOf(lastPathName) !== -1) {
       url.pathname = '/umami.js';
       return NextResponse.rewrite(url);
     }


### PR DESCRIPTION
Although `TRACKER_SCRIPT_NAME` supports customize the track script, we need to change all the site using umami to new track script name at once.

In order to progressively change track script name, this PR allows `TRACKER_SCRIPT_NAME` set multiple names by adding comma. For example:

```bash
TRACKER_SCRIPT_NAME="umami,foo,bar"
```

In this case, `yousite.com/umami.js`, `yoursite.com/foo.js`, `yoursite.com/bar.js` are all redirect to the `umami.js` script.