### PR TITLE
Fix active users not appear

### DIFF
--- a/components/metrics/ActiveUsers.js
+++ b/components/metrics/ActiveUsers.js
@@ -9,14 +9,18 @@ import styles from './ActiveUsers.module.css';
 
 export default function ActiveUsers({ websiteId, className, value, interval = 60000 }) {
   const shareToken = useShareToken();
-  const url = value !== undefined && websiteId ? `/website/${websiteId}/active` : null;
+  const url = websiteId ? `/website/${websiteId}/active` : null;
   const { data } = useFetch(url, {
     interval,
     headers: { [TOKEN_HEADER]: shareToken?.token },
   });
   const count = useMemo(() => {
-    return value || data?.[0]?.x || 0;
-  }, [data, value]);
+    if (websiteId) {
+      return data?.[0]?.x || 0
+    }
+
+    return value !== undefined ? value : 0;
+  }, [data, value, websiteId]);
 
   if (count === 0) {
     return null;

--- a/components/metrics/RealtimeHeader.js
+++ b/components/metrics/RealtimeHeader.js
@@ -33,7 +33,7 @@ export default function RealtimeHeader({ websites, data, websiteId, onSelect }) 
           <FormattedMessage id="label.realtime" defaultMessage="Realtime" />
         </div>
         <div>
-          <ActiveUsers className={styles.active} value={count} />
+          <ActiveUsers className={styles.active} value={count} websiteId={websiteId} />
         </div>
         <DropDown value={websiteId} options={options} onChange={onSelect} />
       </PageHeader>


### PR DESCRIPTION
Fix:
- Active users appear in dashboard
- Display active users specific to website id when on the realtime page

SS:

<img width="765" alt="Screen Shot 2022-03-27 at 11 05 33" src="https://user-images.githubusercontent.com/19968375/160266239-54ceede1-5fdd-4729-893c-cf26f6953a25.png">


<img width="442" alt="Screen Shot 2022-03-27 at 10 59 24" src="https://user-images.githubusercontent.com/19968375/160266241-a5e4e21e-5f31-4deb-a6c5-b597482bf5f3.png">

