### PR TITLE
Dockerfile: update node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
+# Build-time variables
+ARG NODE_VERSION=16
+ARG ALPINE_VERSION=3.15
+
+
 # Build image
-FROM node:12.22-alpine AS build
+FROM node:${NODE_VERSION}-alpine${ALPINE_VERSION} AS build
 ARG BASE_PATH
 ARG DATABASE_TYPE
 
@@ -25,8 +30,9 @@ COPY . /build
 RUN yarn next telemetry disable
 RUN yarn build
 
+
 # Production image
-FROM node:12.22-alpine AS production
+FROM node:${NODE_VERSION}-alpine${ALPINE_VERSION} AS production
 WORKDIR /app
 
 # Copy cached dependencies


### PR DESCRIPTION
Node 16 is the latest LTS so that should be fine. :)
Also security support for Node 12 ends in 3 weeks so just in time!