### PR TITLE
fix: unable to sort by referrer

### DIFF
--- a/lib/queries.js
+++ b/lib/queries.js
@@ -469,7 +469,7 @@ export function getPageviewMetrics(website_id, start_at, end_at, field, table, f
     params.push(decodeURIComponent(url));
   }
 
-  if (referrer) {
+  if (referrer && table !== 'event') {
     refFilter = `and referrer like $${params.length + 1}`;
     params.push(`%${decodeURIComponent(referrer)}%`);
   }


### PR DESCRIPTION
Currently referrer filter will call filter in events table, which will throw an error as no referrer column is in events table.