### PR TITLE
Fix referrer filter issue

### DIFF
--- a/components/metrics/MetricsBar.js
+++ b/components/metrics/MetricsBar.js
@@ -18,7 +18,7 @@ export default function MetricsBar({ websiteId, className }) {
   const { startDate, endDate, modified } = dateRange;
   const [format, setFormat] = useState(true);
   const {
-    query: { url, ref },
+    query: { url, referrer },
   } = usePageQuery();
 
   const { data, error, loading } = useFetch(
@@ -28,11 +28,11 @@ export default function MetricsBar({ websiteId, className }) {
         start_at: +startDate,
         end_at: +endDate,
         url,
-        ref,
+        referrer,
       },
       headers: { [TOKEN_HEADER]: shareToken?.token },
     },
-    [modified, url, ref],
+    [modified, url, referrer],
   );
 
   const formatFunc = format

--- a/lib/queries.js
+++ b/lib/queries.js
@@ -469,7 +469,7 @@ export function getPageviewMetrics(website_id, start_at, end_at, field, table, f
     params.push(decodeURIComponent(url));
   }
 
-  if (referrer) {
+  if (referrer && table !== 'event') {
     refFilter = `and referrer like $${params.length + 1}`;
     params.push(`%${decodeURIComponent(referrer)}%`);
   }

--- a/lib/queries.js
+++ b/lib/queries.js
@@ -424,13 +424,19 @@ export function getPageviewStats(
 
 export function getSessionMetrics(website_id, start_at, end_at, field, filters = {}) {
   const params = [website_id, start_at, end_at];
-  const { url } = filters;
+  const { url, referrer } = filters;
 
   let urlFilter = '';
+  let refFilter = '';
 
   if (url) {
     urlFilter = `and url=$${params.length + 1}`;
     params.push(decodeURIComponent(url));
+  }
+
+  if (referrer) {
+    refFilter = `and referrer like $${params.length + 1}`;
+    params.push(`%${decodeURIComponent(referrer)}%`);
   }
 
   return rawQuery(
@@ -443,6 +449,7 @@ export function getSessionMetrics(website_id, start_at, end_at, field, filters =
       where website_id=$1
       and created_at between $2 and $3
       ${urlFilter}
+      ${refFilter}
     )
     group by 1
     order by 2 desc

--- a/pages/api/website/[id]/metrics.js
+++ b/pages/api/website/[id]/metrics.js
@@ -40,7 +40,7 @@ export default async (req, res) => {
     const endDate = new Date(+end_at);
 
     if (sessionColumns.includes(type)) {
-      let data = await getSessionMetrics(websiteId, startDate, endDate, type, { url });
+      let data = await getSessionMetrics(websiteId, startDate, endDate, type, { url, referrer });
 
       if (type === 'language') {
         let combined = {};


### PR DESCRIPTION
Add check before referrer filter in `events` database as there is no referrer data recorded.
Further address the issue in #1043 to refresh dashboard when referrer filters applied.