### PR TITLE
fix: session not filtered by pageviews

### DIFF
--- a/lib/queries.js
+++ b/lib/queries.js
@@ -64,9 +64,10 @@ export function getFilterQuery(table, filters = {}, params = []) {
 
     switch (key) {
       case 'url':
-        if (table === 'session' || table === 'pageview') {
-          arr.push(`and ${table}.${key}=$${params.length + 1}`);
+        if (table === 'session' || table === 'pageview' || table === 'event') {
+          arr.push(`and (${table}.${key}=$${params.length + 1} or ${table}.${key} like $${params.length + 2})`);
           params.push(decodeURIComponent(value));
+          params.push(`${decodeURIComponent(value)}?%`);
         }
         break;
 
@@ -125,7 +126,7 @@ export function parseFilters(table, filters = {}, params = []) {
       os || browser || device || country
         ? `inner join session on ${table}.session_id = session.session_id`
         : '',
-    pageviewQuery: getFilterQuery('pageview', pageviewFilters, params),
+    pageviewQuery: table === 'event' ? getFilterQuery('event', pageviewFilters, params) : getFilterQuery('pageview', pageviewFilters, params),
     sessionQuery: getFilterQuery('session', sessionFilters, params),
     eventQuery: getFilterQuery('event', eventFilters, params),
   };

--- a/lib/queries.js
+++ b/lib/queries.js
@@ -65,9 +65,11 @@ export function getFilterQuery(table, filters = {}, params = []) {
     switch (key) {
       case 'url':
         if (table === 'session' || table === 'pageview' || table === 'event') {
-          arr.push(`and (${table}.${key}=$${params.length + 1} or ${table}.${key} like $${params.length + 2})`);
+          arr.push(`and (${table}.${key}=$${params.length + 1} or ${table}.${key} like $${params.length + 2} or (${table}.${key} like $${params.length + 3} and ${table}.${key} not like $${params.length + 4}))`);
           params.push(decodeURIComponent(value));
           params.push(`${decodeURIComponent(value)}?%`);
+          params.push(`%${decodeURIComponent(value)}#%`);
+          params.push(`%${decodeURIComponent(value)}#/%`);
         }
         break;
 

--- a/pages/api/website/[id]/metrics.js
+++ b/pages/api/website/[id]/metrics.js
@@ -41,6 +41,8 @@ export default async (req, res) => {
 
     if (sessionColumns.includes(type)) {
       let data = await getSessionMetrics(websiteId, startDate, endDate, type, {
+        url,
+        referrer,
         os,
         browser,
         device,


### PR DESCRIPTION
- fix session not filtered by pageviews
- [WIP] fix events not filtered by pageviews
AT present, if we filter events by url/referrer, the db will throw error as we had not `from` the pageview db. As far as my trials here, I have not found a perfect way without further refactoring the code.
I'll leave the issue here for now and you may close my PR and use your solution at any time (as im a little busy right now and might not have time for this right now TAT)
From my experience.
 1. We should still filter events by referrer in the whole session. However, this is not recorded in the event db and we need to reference that from session db.
 2. We can simple filter events by url in events db, but the current getFilterQuery won't allow us to do this https://github.com/mikecao/umami/blob/8384d6af352a9393310540cf0c02fff3aee64cbc/lib/queries.js#L57
I'll get back to do this ASAP, but feel free to change my commit according to your design :-)