### PR TITLE
Update README.md with DATABASE_TYPE

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This will also create a login account with username **admin** and password **uma
 Create an `.env` file with the following
 
 ```
+DATABASE_TYPE=mysql or postgres
 DATABASE_URL=(connection url)
 HASH_SALT=(any random string)
 ```


### PR DESCRIPTION
According to the `copy-db-schema` file, `DATABASE_TYPE` env variable is necessary, but missing from the README.

https://github.com/mikecao/umami/blob/f8ac987bfc0df581721bd2c9b0b9d9555698c346/scripts/copy-db-schema.js