### PR TITLE
use outputStandalone to reduce docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,45 +1,52 @@
-# Build image
-FROM node:12.22-alpine AS build
-ARG BASE_PATH
-ARG DATABASE_TYPE
+# Install dependencies only when needed
+FROM node:16-alpine AS deps
+# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile
 
+# Rebuild the source code only when needed
+FROM node:16-alpine AS builder
 ENV BASE_PATH=$BASE_PATH
 ENV DATABASE_URL "postgresql://umami:umami@db:5432/umami"
 ENV DATABASE_TYPE=$DATABASE_TYPE
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
 
-WORKDIR /build
+# Next.js collects completely anonymous telemetry data about general usage.
+# Learn more here: https://nextjs.org/telemetry
+# Uncomment the following line in case you want to disable telemetry during the build.
+ENV NEXT_TELEMETRY_DISABLED 1
 
-RUN yarn config set --home enableTelemetry 0
-COPY package.json yarn.lock /build/
-
-# Install only the production dependencies
-RUN yarn install --production --frozen-lockfile
-
-# Cache these modules for production
-RUN cp -R node_modules/ prod_node_modules/
-
-# Install development dependencies
-RUN yarn install --frozen-lockfile
-
-COPY . /build
-RUN yarn next telemetry disable
 RUN yarn build
 
-# Production image
-FROM node:12.22-alpine AS production
+# Production image, copy all the files and run next
+FROM node:16-alpine AS runner
 WORKDIR /app
 
-# Copy cached dependencies
-COPY --from=build /build/prod_node_modules ./node_modules
+ENV NODE_ENV production
+# Uncomment the following line in case you want to disable telemetry during runtime.
+ENV NEXT_TELEMETRY_DISABLED 1
 
-# Copy generated Prisma client
-COPY --from=build /build/node_modules/.prisma/ ./node_modules/.prisma/
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
 
-COPY --from=build /build/yarn.lock /build/package.json ./
-COPY --from=build /build/.next ./.next
-COPY --from=build /build/public ./public
+# You only need to copy next.config.js if you are NOT using the default configuration
+COPY --from=builder /app/next.config.js ./
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/package.json ./package.json
 
-USER node
+# Automatically leverage output traces to reduce image size 
+# https://nextjs.org/docs/advanced-features/output-file-tracing
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
 
 EXPOSE 3000
-CMD ["yarn", "start"]
+
+ENV PORT 3000
+
+CMD ["node", "server.js"]

--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,9 @@ module.exports = {
     VERSION: pkg.version,
   },
   basePath: process.env.BASE_PATH,
+  experimental: {
+    outputStandalone: true,
+  },
   eslint: {
     ignoreDuringBuilds: true,
   },


### PR DESCRIPTION
This PR enables the [experimental output file tracing](https://nextjs.org/docs/advanced-features/output-file-tracing#automatically-copying-traced-files-experimental) to reduce the size of the Docker container and to ease the copying of necessary files to the docker container. It is based of the [next.js Docker example](https://github.com/vercel/next.js/tree/canary/examples/with-docker)