### PR TITLE
Fix missing Dashboard translation

### DIFF
--- a/components/pages/Dashboard.js
+++ b/components/pages/Dashboard.js
@@ -32,7 +32,9 @@ export default function Dashboard() {
   return (
     <Page>
       <PageHeader>
-        <div>Dashboard</div>
+        <div>
+          <FormattedMessage id="label.dashboard" defaultMessage="Dashboard" />
+        </div>
         <DashboardSettingsButton />
       </PageHeader>
       <WebsiteList websites={data} showCharts={showCharts} limit={max} />


### PR DESCRIPTION
Fix the missing dashboard translation
before:
![QQ截图20220601134938](https://user-images.githubusercontent.com/734749/171401357-32f8f7c6-f3c7-4e88-bff4-866dba7bd34f.png)
after:
![QQ截图20220601140938](https://user-images.githubusercontent.com/734749/171401361-aba25407-4268-4371-ae4a-e8518361cbfa.png)
